### PR TITLE
 Add Decode & Encode Macro Support

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,6 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [CodableKit, CodableKitShared]
+    - documentation_targets 
+      - CodableKit
+      - CodableKitShared

--- a/Sources/CodableKit/CodableKit.swift
+++ b/Sources/CodableKit/CodableKit.swift
@@ -55,8 +55,16 @@
 /// }
 /// ```
 @attached(extension, conformances: Codable, names: named(CodingKeys), named(init(from:)))
-@attached(member, names: named(init(from:)), named(encode(to:)))
+@attached(member, conformances: Codable, names: named(init(from:)), named(encode(to:)))
 public macro Codable() = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
+
+@attached(extension, conformances: Decodable, names: named(CodingKeys), named(init(from:)))
+@attached(member, conformances: Decodable, names: named(init(from:)))
+public macro Decodable() = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
+
+@attached(extension, conformances: Encodable, names: named(CodingKeys))
+@attached(member, conformances: Encodable, names: named(encode(to:)))
+public macro Encodable() = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
 
 /// Custom the key used for encoding and decoding a property.
 ///

--- a/Sources/CodableKit/CodableKit.swift
+++ b/Sources/CodableKit/CodableKit.swift
@@ -58,10 +58,82 @@
 @attached(member, conformances: Codable, names: named(init(from:)), named(encode(to:)))
 public macro Codable() = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
 
+/// A macro that generates `Decodable` conformance and boilerplate code for a struct, such that the Decodable struct can
+/// have default values for its properties, and custom keys for encoding and decoding with `@CodableKey`.
+///
+/// Suppose you have a struct like this:
+///
+/// ```swift
+/// @Decodable
+/// struct User {
+///   @CodableKey("uid") let id: Int
+///   let id: Int
+///   let name: String
+///   let email: String
+///   var age: Int = 25
+/// }
+/// ```
+///
+/// It will generate the following code:
+///
+/// ```swift
+/// extension User: Decodable {
+///   enum CodingKeys: String, CodingKey {
+///     case id = "uid"
+///     case name
+///     case email
+///     case age
+///   }
+///
+///   init(from decoder: Decoder) throws {
+///     let container = try decoder.container(keyedBy: CodingKeys.self)
+///     id = try container.decode(Int.self, forKey: .id)
+///     name = try container.decode(String.self, forKey: .name)
+///     email = try container.decode(String.self, forKey: .email)
+///     age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 25
+///   }
+/// }
+/// ```
 @attached(extension, conformances: Decodable, names: named(CodingKeys), named(init(from:)))
 @attached(member, conformances: Decodable, names: named(init(from:)))
 public macro Decodable() = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
 
+/// A macro that generates `Encodable` conformance and boilerplate code for a struct, such that the Encodable struct can
+/// have default values for its properties, and custom keys for encoding and decoding with `@CodableKey`.
+///
+/// Suppose you have a struct like this:
+///
+/// ```swift
+/// @Codable
+/// struct User {
+///   @CodableKey("uid") let id: Int
+///   let id: Int
+///   let name: String
+///   let email: String
+///   var age: Int = 25
+/// }
+/// ```
+///
+/// It will generate the following code:
+///
+/// ```swift
+/// extension User: Encodable {
+///   enum CodingKeys: String, CodingKey {
+///     case id = "uid"
+///     case name
+///     case email
+///     case age
+///   }
+///
+///   func encode(to encoder: Encoder) throws {
+///     var container = encoder.container(keyedBy: CodingKeys.self)
+///     try container.encode(id, forKey: .id)
+///     try container.encode(name, forKey: .name)
+///     try container.encode(email, forKey: .email)
+///     try container.encode(age, forKey: .age)
+///   }
+/// }
+/// ```
 @attached(extension, conformances: Encodable, names: named(CodingKeys))
 @attached(member, conformances: Encodable, names: named(encode(to:)))
 public macro Encodable() = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")

--- a/Sources/CodableKitMacros/CodableMacro.swift
+++ b/Sources/CodableKitMacros/CodableMacro.swift
@@ -114,9 +114,9 @@ extension CodableMacro: MemberMacro {
     case .structType, .enumType:
       break
     }
-    
+
     var result: [DeclSyntax] = []
-    
+
     switch structureType {
     case .classType:
       if codableType.contains(.decodable) {

--- a/Sources/CodableKitMacros/CodableProperty.swift
+++ b/Sources/CodableKitMacros/CodableProperty.swift
@@ -48,7 +48,7 @@ struct CodableProperty {
     self.type = binding.typeAnnotation?.type.trimmed ?? type.trimmed
     self.defaultValue = binding.initializer?.value
   }
-  
+
   /// Initializes a `CodableMacro.Property` instance.
   ///
   /// - Parameters:
@@ -125,7 +125,7 @@ extension CodableProperty {
   var shouldGenerateCustomCodingKeyVariable: Bool {
     customCodableKey != nil && options.contains(.generateCustomKey)
   }
-  
+
   func checkOptionsAvailability(for type: StructureType) throws(CustomError) {
     switch type {
     case .enumType:

--- a/Sources/CodableKitMacros/CodableType.swift
+++ b/Sources/CodableKitMacros/CodableType.swift
@@ -1,0 +1,37 @@
+//
+//  CodableType.swift
+//  CodableKit
+//
+//  Created by Wendell Wang on 2024/11/29.
+//
+
+import SwiftSyntax
+
+internal struct CodableType: OptionSet {
+  let rawValue: Int8
+  
+  static let none: CodableType = []
+  static let codable: CodableType = [.decodable, .encodable]
+  static let decodable = CodableType(rawValue: 1 << 0)
+  static let encodable = CodableType(rawValue: 1 << 1)
+  
+  static func from(_ protocols: [TypeSyntax]) -> CodableType {
+    var codableType = CodableType.none
+    
+    for `protocol` in protocols {
+      guard let name = `protocol`.as(IdentifierTypeSyntax.self)?.name.trimmed.text else { continue }
+      switch name {
+      case "Codable":
+        codableType.insert(.codable)
+      case "Decodable":
+        codableType.insert(.decodable)
+      case "Encodable":
+        codableType.insert(.encodable)
+      default:
+        break
+      }
+    }
+    
+    return codableType
+  }
+}

--- a/Sources/CodableKitMacros/CodableType.swift
+++ b/Sources/CodableKitMacros/CodableType.swift
@@ -9,15 +9,15 @@ import SwiftSyntax
 
 internal struct CodableType: OptionSet {
   let rawValue: Int8
-  
+
   static let none: CodableType = []
   static let codable: CodableType = [.decodable, .encodable]
   static let decodable = CodableType(rawValue: 1 << 0)
   static let encodable = CodableType(rawValue: 1 << 1)
-  
+
   static func from(_ protocols: [TypeSyntax]) -> CodableType {
     var codableType = CodableType.none
-    
+
     for `protocol` in protocols {
       guard let name = `protocol`.as(IdentifierTypeSyntax.self)?.name.trimmed.text else { continue }
       switch name {
@@ -31,7 +31,7 @@ internal struct CodableType: OptionSet {
         break
       }
     }
-    
+
     return codableType
   }
 }

--- a/Sources/CodableKitShared/CodableKeyOptions.swift
+++ b/Sources/CodableKitShared/CodableKeyOptions.swift
@@ -17,7 +17,7 @@ public struct CodableKeyOptions: OptionSet, Sendable {
 
   /// The default options for a `CodableKey`, which is equivalent to an empty set.
   public static let `default`: Self = []
-  
+
   /// The key will be ignored during encoding and decoding.
   ///
   /// This option is useful when you want to add a local or runtime-only property to the structure without creating
@@ -26,11 +26,11 @@ public struct CodableKeyOptions: OptionSet, Sendable {
   /// -  Important: Using the `.ignored` option for an enum case may lead to runtime issues if you attempt to decode
   /// or encode the enum with that case using the `.ignored` option.
   public static let ignored = Self(rawValue: 1 << 0)
-  
+
   /// The key will be explicitly set to `nil` (`null`) when encoding and decoding.
   /// By default, the key will be omitted if the value is `nil`.
   public static let explicitNil = Self(rawValue: 1 << 1)
-  
+
   /// If the key has a custom CodableKey, a computed property will be generated to access the key; otherwise, this
   /// option is ignored.
   ///
@@ -55,7 +55,7 @@ public struct CodableKeyOptions: OptionSet, Sendable {
   /// }
   /// ```
   public static let generateCustomKey = Self(rawValue: 1 << 2)
-  
+
   /// Transcode the value between raw string and the target type.
   ///
   /// This is useful when the value needs to be converted from a string to another
@@ -76,7 +76,7 @@ public struct CodableKeyOptions: OptionSet, Sendable {
   /// }
   /// ```
   public static let transcodeRawString = Self(rawValue: 1 << 3)
-  
+
   /// Use the default value (if set) when decode or encode fails.
   ///
   /// This option is only valid when the property has a default value or is optional (like `String?`).

--- a/Tests/CodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -13,7 +13,7 @@ import XCTest
 
 final class CodableKitTestsForSubClass: XCTestCase {
   func testMacros() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -54,16 +54,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDefaultValue() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -104,16 +102,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithCodableKeyAndDefaultValue() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -155,16 +151,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithOptionalValue() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -205,16 +199,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithIgnoredCodableKey() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -258,16 +250,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithExplicitNil() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -314,16 +304,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithOneCustomKeyGenerated() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -369,16 +357,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithTwoCustomKeyGenerated() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -429,16 +415,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDecodingRawString() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       struct Room: Codable {
@@ -515,16 +499,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDecodingRawStringAndIgnoreError() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       struct Room: Codable {
@@ -601,16 +583,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDecodingRawStringWithDefaultValueAndIgnoreError() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       struct Room: Codable {
@@ -687,16 +667,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacrosWithOptionUseDefaultOnFailure() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       enum Role: UInt8, Codable {
@@ -753,11 +731,9 @@ final class CodableKitTestsForSubClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 }

--- a/Tests/CodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class.swift
@@ -13,7 +13,6 @@ import XCTest
 
 final class CodableKitTestsForClass: XCTestCase {
   func testMacros() throws {
-    #if canImport(CodableKitMacros)
     assertMacroExpansion(
       """
       @Codable
@@ -52,16 +51,13 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
   }
 
   func testMacroWithDefaultValue() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -100,16 +96,14 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithCodableKeyAndDefaultValue() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -149,16 +143,14 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithOptionalValue() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -197,16 +189,14 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithIgnoredCodableKey() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -248,16 +238,14 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithExplicitNil() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -302,16 +290,14 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithOneCustomKeyGenerated() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -355,16 +341,14 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithTwoCustomKeyGenerated() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -413,16 +397,14 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDecodingRawString() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       struct Room: Codable {
@@ -497,16 +479,14 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDecodingRawStringAndIgnoreError() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       struct Room: Codable {
@@ -581,16 +561,14 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDecodingRawStringWithDefaultValueAndIgnoreError() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       struct Room: Codable {
@@ -665,16 +643,14 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacrosWithOptionUseDefaultOnFailure() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       enum Role: UInt8, Codable {
@@ -729,11 +705,9 @@ final class CodableKitTestsForClass: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 }

--- a/Tests/CodableKitTests/CodableMacroTests+diagnostics.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+diagnostics.swift
@@ -14,7 +14,6 @@ import XCTest
 
 final class CodableKitDiagnosticsTests: XCTestCase {
   func testMacroWithNoTypeAnnotation() throws {
-    #if canImport(CodableKitMacros)
     assertMacroExpansion(
       """
       @Codable
@@ -34,16 +33,13 @@ final class CodableKitDiagnosticsTests: XCTestCase {
       diagnostics: [
         .init(message: "Properties must have a type annotation", line: 1, column: 1)
       ],
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
   }
 
   func testMacroWithIgnoredPropertyTypeAnnotation() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -85,16 +81,14 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithStaticTypeAnnotation() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -137,16 +131,14 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroOnComputeProperty() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -195,16 +187,14 @@ final class CodableKitDiagnosticsTests: XCTestCase {
       diagnostics: [
         .init(message: "Only variable declarations with no accessor block are supported", line: 6, column: 3)
       ],
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroOnStaticComputeProperty() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -253,16 +243,14 @@ final class CodableKitDiagnosticsTests: XCTestCase {
       diagnostics: [
         .init(message: "Only variable declarations with no accessor block are supported", line: 6, column: 3)
       ],
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroOnStaticProperty() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -307,11 +295,9 @@ final class CodableKitDiagnosticsTests: XCTestCase {
       diagnostics: [
         .init(message: "Only non-static variable declarations are supported", line: 6, column: 3)
       ],
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 }

--- a/Tests/CodableKitTests/CodableMacroTests+enum.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+enum.swift
@@ -13,7 +13,7 @@ import XCTest
 
 final class CodableKitTestsForEnum: XCTestCase {
   func testMacros() throws {
-#if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -29,7 +29,7 @@ final class CodableKitTestsForEnum: XCTestCase {
             case int(Int)
             case none
         }
-        
+
         extension TestEnum: Codable {
           enum CodingKeys: String, CodingKey {
             case string
@@ -38,16 +38,14 @@ final class CodableKitTestsForEnum: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-#else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-#endif
+
   }
-  
+
   func testMacrosWithCodableKey() throws {
-#if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -63,7 +61,7 @@ final class CodableKitTestsForEnum: XCTestCase {
             case int(Int)
             case none
         }
-        
+
         extension TestEnum: Codable {
           enum CodingKeys: String, CodingKey {
             case string = "str"
@@ -72,16 +70,14 @@ final class CodableKitTestsForEnum: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-#else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-#endif
+
   }
-  
+
   func testMacrosWithIgnoredCodableKey() throws {
-#if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -97,7 +93,7 @@ final class CodableKitTestsForEnum: XCTestCase {
             case int(Int)
             case none
         }
-        
+
         extension TestEnum: Codable {
           enum CodingKeys: String, CodingKey {
             case string = "str"
@@ -105,16 +101,14 @@ final class CodableKitTestsForEnum: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-#else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-#endif
+
   }
-  
+
   func testMacrosWithIndirectCase() throws {
-#if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -134,7 +128,7 @@ final class CodableKitTestsForEnum: XCTestCase {
             indirect case nestedA(TestEnum)
             indirect case nestedB(TestEnum)
         }
-        
+
         extension TestEnum: Codable {
           enum CodingKeys: String, CodingKey {
             case string = "str"
@@ -145,11 +139,9 @@ final class CodableKitTestsForEnum: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-#else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-#endif
+
   }
 }

--- a/Tests/CodableKitTests/CodableMacroTests+struct.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+struct.swift
@@ -13,7 +13,7 @@ import XCTest
 
 final class CodableKitTestsForStruct: XCTestCase {
   func testMacros() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -52,16 +52,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDefaultValue() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -100,16 +98,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithCodableKeyAndDefaultValue() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -149,16 +145,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithOptionalValue() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -197,16 +191,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithIgnoredCodableKey() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -248,16 +240,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithExplicitNil() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -302,16 +292,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithOneCustomKeyGenerated() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -355,16 +343,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithTwoCustomKeyGenerated() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       @Codable
@@ -413,16 +399,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDecodingRawString() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       struct Room: Codable {
@@ -497,16 +481,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDecodingRawStringAndIgnoreError() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       struct Room: Codable {
@@ -581,16 +563,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacroWithDecodingRawStringWithDefaultValueAndIgnoreError() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       struct Room: Codable {
@@ -665,16 +645,14 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 
   func testMacrosWithOptionUseDefaultOnFailure() throws {
-    #if canImport(CodableKitMacros)
+
     assertMacroExpansion(
       """
       enum Role: UInt8, Codable {
@@ -729,11 +707,9 @@ final class CodableKitTestsForStruct: XCTestCase {
           }
         }
         """,
-      macros: macros,
+      macroSpecs: macroSpecs,
       indentationWidth: .spaces(2)
     )
-    #else
-    throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+
   }
 }

--- a/Tests/CodableKitTests/Defines.swift
+++ b/Tests/CodableKitTests/Defines.swift
@@ -6,13 +6,18 @@
 //  Copyright © 2024 WendellXY. All rights reserved.
 //
 
-import SwiftSyntaxMacros
-
-#if canImport(CodableKitMacros)
 import CodableKitMacros
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
 
 let macros: [String: any Macro.Type] = [
   "Codable": CodableMacro.self,
   "CodableKey": CodableKeyMacro.self,
 ]
-#endif
+
+let macroSpecs: [String: MacroSpec] = [
+  "Codable": MacroSpec(type: CodableMacro.self, conformances: ["Codable"]),
+  "CodableKey": MacroSpec(type: CodableKeyMacro.self),
+]


### PR DESCRIPTION
This pull request introduces support for `Encodable` and `Decodable` macros, enhancing the serialization and deserialization capabilities of our codebase. 

**Changes Made:**
- Added `@Encodable` and `@Decodable` macros to streamline the process of encoding and decoding data structures.
- Updated the test cases to ensure that the new macros are functioning correctly and that existing functionality remains intact.
- Reformatted files to adhere to the project's coding standards.