### PR TITLE
Remove binary build configuration from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -69,35 +69,3 @@ let package = Package(
     ),
   ]
 )
-
-let buildForBinary = ProcessInfo.processInfo.environment["BUILD_FOR_BINARY"]?.lowercased() == "true"
-
-if buildForBinary {
-  package.products = [
-    .executable(
-      name: "CodableKitMacros",
-      targets: ["CodableKitMacros"]
-    )
-  ]
-
-  package.targets = package.targets.compactMap { target in
-    if target.type == .macro {
-      .executableTarget(
-        name: target.name,
-        dependencies: target.dependencies,
-        path: target.path,
-        exclude: target.exclude,
-        sources: target.sources,
-        resources: target.resources,
-        publicHeadersPath: target.publicHeadersPath,
-        cSettings: target.cSettings,
-        cxxSettings: target.cxxSettings,
-        swiftSettings: target.swiftSettings,
-        linkerSettings: target.linkerSettings,
-        plugins: target.plugins
-      )
-    } else {
-      target
-    }
-  }
-}

--- a/build_binary.sh
+++ b/build_binary.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-export BUILD_FOR_BINARY=true
-swift build -c release


### PR DESCRIPTION
Eliminate the binary build configuration from the Package.swift file and 
the associated build_binary.sh script.