### PR TITLE
Add `skipSuperCoding` Codable Options

### DIFF
--- a/Sources/CodableKit/CodableKit.swift
+++ b/Sources/CodableKit/CodableKit.swift
@@ -56,7 +56,9 @@
 /// ```
 @attached(extension, conformances: Codable, names: named(CodingKeys), named(init(from:)))
 @attached(member, conformances: Codable, names: named(init(from:)), named(encode(to:)))
-public macro Codable() = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
+public macro Codable(
+  options: CodableOptions = .default
+) = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
 
 /// A macro that generates `Decodable` conformance and boilerplate code for a struct, such that the Decodable struct can
 /// have default values for its properties, and custom keys for encoding and decoding with `@CodableKey`.
@@ -96,7 +98,9 @@ public macro Codable() = #externalMacro(module: "CodableKitMacros", type: "Codab
 /// ```
 @attached(extension, conformances: Decodable, names: named(CodingKeys), named(init(from:)))
 @attached(member, conformances: Decodable, names: named(init(from:)))
-public macro Decodable() = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
+public macro Decodable(
+  options: CodableOptions = .default
+) = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
 
 /// A macro that generates `Encodable` conformance and boilerplate code for a struct, such that the Encodable struct can
 /// have default values for its properties, and custom keys for encoding and decoding with `@CodableKey`.
@@ -136,7 +140,9 @@ public macro Decodable() = #externalMacro(module: "CodableKitMacros", type: "Cod
 /// ```
 @attached(extension, conformances: Encodable, names: named(CodingKeys))
 @attached(member, conformances: Encodable, names: named(encode(to:)))
-public macro Encodable() = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
+public macro Encodable(
+  options: CodableOptions = .default
+) = #externalMacro(module: "CodableKitMacros", type: "CodableMacro")
 
 /// Custom the key used for encoding and decoding a property.
 ///

--- a/Sources/CodableKitMacros/CodableMacro.swift
+++ b/Sources/CodableKitMacros/CodableMacro.swift
@@ -38,7 +38,10 @@ extension CodableMacro: ExtensionMacro {
     guard !properties.isEmpty else { return [] }
 
     let inheritanceClause: InheritanceClauseSyntax? =
-      if case .classType(let hasSuperclass) = structureType, hasSuperclass {
+      if case .classType(let hasSuperclass) = structureType,
+        hasSuperclass,
+        !codableOptions.contains(.skipSuperCoding)
+      {
         nil
       } else {
         InheritanceClauseSyntax {

--- a/Sources/CodableKitShared/CodableOptions.swift
+++ b/Sources/CodableKitShared/CodableOptions.swift
@@ -1,0 +1,67 @@
+//
+//  CodableOptions.swift
+//  CodableKit
+//
+//  Created by Wendell Wang on 2025/1/13.
+//
+
+import SwiftSyntax
+
+/// Options that customize the behavior of the `@Codable` macro expansion.
+public struct CodableOptions: OptionSet, Sendable {
+  public let rawValue: Int32
+  
+  public init(rawValue: Int32) {
+    self.rawValue = rawValue
+  }
+  
+  /// The default options, which perform standard Codable expansion with super encode/decode calls.
+  public static let `default`: Self = []
+  
+  /// Skips generating super encode/decode calls in the expanded code.
+  ///
+  /// Use this option when the superclass doesn't conform to `Codable`.
+  /// When enabled:
+  /// - Replaces `super.init(from: decoder)` with `super.init()`
+  /// - Removes `super.encode(to: encoder)` call entirely
+  public static let skipSuperCoding = Self(rawValue: 1 << 0)
+}
+
+extension CodableOptions {
+  package init(from expr: MemberAccessExprSyntax) {
+    let variableName = expr.declName.baseName.text
+    switch variableName {
+    case "skipSuperCoding":
+      self = .skipSuperCoding
+    default:
+      self = .default
+    }
+  }
+}
+
+extension CodableOptions {
+  /// Parse the options from 1a `LabelExprSyntax`. It support parse a single element like `.default`,
+  /// or multiple elements like `[.ignored, .explicitNil]`
+  package static func parse(from labeledExpr: LabeledExprSyntax) -> Self {
+    if let memberAccessExpr = labeledExpr.expression.as(MemberAccessExprSyntax.self) {
+      Self.init(from: memberAccessExpr)
+    } else if let arrayExpr = labeledExpr.expression.as(ArrayExprSyntax.self) {
+      arrayExpr.elements
+        .compactMap { $0.expression.as(MemberAccessExprSyntax.self) }
+        .map { Self.init(from: $0) }
+        .reduce(.default) { $0.union($1) }
+    } else {
+      .default
+    }
+  }
+}
+
+extension LabeledExprSyntax {
+  /// Parse the options from a `LabelExprSyntax`. It support parse a single element like .default,
+  /// or multiple elements like [.ignored, .explicitNil].
+  ///
+  /// This is a convenience method to use for chaining.
+  package func parseCodableOptions() -> CodableOptions {
+    CodableOptions.parse(from: self)
+  }
+}

--- a/Tests/CodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -736,4 +736,51 @@ final class CodableKitTestsForSubClass: XCTestCase {
     )
 
   }
+  
+  func testMacrosWithCodableOptionSkipSuperCoding() throws {
+
+    assertMacroExpansion(
+      """
+      @Codable(options: .skipSuperCoding)
+      public class User: NSObject {
+        let id: UUID
+        let name: String
+        let age: Int
+      }
+      """,
+      expandedSource: """
+        public class User: NSObject {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          public required init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            age = try container.decode(Int.self, forKey: .age)
+            super.init()
+          }
+
+          public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try container.encode(age, forKey: .age)
+          }
+        }
+
+        extension User: Codable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+        }
+        """,
+      macroSpecs: macroSpecs,
+      indentationWidth: .spaces(2)
+    )
+
+  }
 }

--- a/Tests/CodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class.swift
@@ -710,4 +710,50 @@ final class CodableKitTestsForClass: XCTestCase {
     )
 
   }
+  
+  func testMacrosWithCodableOptionSkipSuperCoding() throws {
+
+    assertMacroExpansion(
+      """
+      @Codable(options: .skipSuperCoding)
+      public class User {
+        let id: UUID
+        let name: String
+        let age: Int
+      }
+      """,
+      expandedSource: """
+        public class User {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          public required init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            age = try container.decode(Int.self, forKey: .age)
+          }
+
+          public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try container.encode(age, forKey: .age)
+          }
+        }
+
+        extension User: Codable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+        }
+        """,
+      macroSpecs: macroSpecs,
+      indentationWidth: .spaces(2)
+    )
+
+  }
 }

--- a/Tests/DecodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -602,4 +602,44 @@ final class CodableKitTestsForSubClass: XCTestCase {
     )
 
   }
+  
+  func testMacrosWithCodableOptionSkipSuperCoding() throws {
+
+    assertMacroExpansion(
+      """
+      @Decodable(options: .skipSuperCoding)
+      public class User: NSObject {
+        let id: UUID
+        let name: String
+        let age: Int
+      }
+      """,
+      expandedSource: """
+        public class User: NSObject {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          public required init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            age = try container.decode(Int.self, forKey: .age)
+            super.init()
+          }
+        }
+
+        extension User: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+        }
+        """,
+      macroSpecs: macroSpecs,
+      indentationWidth: .spaces(2)
+    )
+
+  }
 }

--- a/Tests/DecodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+class.swift
@@ -588,4 +588,43 @@ final class CodableKitTestsForClass: XCTestCase {
     )
 
   }
+  
+  func testMacrosWithCodableOptionSkipSuperCoding() throws {
+
+    assertMacroExpansion(
+      """
+      @Decodable(options: .skipSuperCoding)
+      public class User {
+        let id: UUID
+        let name: String
+        let age: Int
+      }
+      """,
+      expandedSource: """
+        public class User {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          public required init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            age = try container.decode(Int.self, forKey: .age)
+          }
+        }
+
+        extension User: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+        }
+        """,
+      macroSpecs: macroSpecs,
+      indentationWidth: .spaces(2)
+    )
+
+  }
 }

--- a/Tests/EncodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -602,4 +602,43 @@ final class CodableKitTestsForSubClass: XCTestCase {
     )
 
   }
+  
+  func testMacrosWithCodableOptionSkipSuperCoding() throws {
+
+    assertMacroExpansion(
+      """
+      @Encodable(options: .skipSuperCoding)
+      public class User: NSObject {
+        let id: UUID
+        let name: String
+        let age: Int
+      }
+      """,
+      expandedSource: """
+        public class User: NSObject {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try container.encode(age, forKey: .age)
+          }
+        }
+
+        extension User: Encodable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+        }
+        """,
+      macroSpecs: macroSpecs,
+      indentationWidth: .spaces(2)
+    )
+
+  }
 }

--- a/Tests/EncodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+class.swift
@@ -588,4 +588,43 @@ final class CodableKitTestsForClass: XCTestCase {
     )
 
   }
+  
+  func testMacrosWithCodableOptionSkipSuperCoding() throws {
+
+    assertMacroExpansion(
+      """
+      @Encodable(options: .skipSuperCoding)
+      public class User {
+        let id: UUID
+        let name: String
+        let age: Int
+      }
+      """,
+      expandedSource: """
+        public class User {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try container.encode(age, forKey: .age)
+          }
+        }
+
+        extension User: Encodable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+        }
+        """,
+      macroSpecs: macroSpecs,
+      indentationWidth: .spaces(2)
+    )
+
+  }
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the `@Codable` macro by adding a new feature called `CodableOptions`, which allows for customizable behavior when encoding and decoding types. 

- **CodableOptions Implementation**: A new `CodableOptions` structure has been introduced to enable users to customize the behavior of the `@Codable` macro. This includes the ability to skip superclass encode/decode calls when the superclass does not conform to `Codable`. This change enhances flexibility in code generation and allows for more tailored implementations of Codable types.
  
- **Inheritance Logic Update**: The logic within the `CodableMacro` has been updated to ensure that superclass coding is not skipped unless the `skipSuperCoding` option is explicitly set. This ensures that all relevant properties from superclasses are encoded correctly, improving the handling of inheritance in Codable types.

- **Comprehensive Testing**: New tests have been added to validate the functionality of the `@Encodable`, `@Decodable`, and `@Codable` macros with the `.skipSuperCoding` option. These tests ensure that the macros expand correctly to the expected Swift code and that the generated classes handle encoding and decoding appropriately, even when not inheriting properties from superclasses. This enhances the overall test coverage for the Codable macros.

These changes aim to improve the usability and reliability of the Codable macros, making them more adaptable to various coding scenarios.