### PR TITLE
Add lifecycle hooks to CodableKit macros

### DIFF
--- a/Sources/CodableKit/CodableKit.swift
+++ b/Sources/CodableKit/CodableKit.swift
@@ -57,7 +57,7 @@
 ///
 /// - Parameters:
 ///   - options: Options for customizing the behavior of the key.
-@attached(extension, conformances: Codable, names: named(CodingKeys), named(init(from:)))
+@attached(extension, conformances: Codable, CodableHooks, names: named(CodingKeys), named(init(from:)))
 @attached(member, conformances: Codable, names: named(init(from:)), named(encode(to:)))
 public macro Codable(
   options: CodableOptions = .default
@@ -102,7 +102,7 @@ public macro Codable(
 ///
 /// - Parameters:
 ///   - options: Options for customizing the behavior of the key.
-@attached(extension, conformances: Decodable, names: named(CodingKeys), named(init(from:)))
+@attached(extension, conformances: Decodable, DecodingHooks, names: named(CodingKeys), named(init(from:)))
 @attached(member, conformances: Decodable, names: named(init(from:)))
 public macro Decodable(
   options: CodableOptions = .default
@@ -147,7 +147,7 @@ public macro Decodable(
 ///
 /// - Parameters:
 ///   - options: Options for customizing the behavior of the key.
-@attached(extension, conformances: Encodable, names: named(CodingKeys))
+@attached(extension, conformances: Encodable, EncodingHooks, names: named(CodingKeys))
 @attached(member, conformances: Encodable, names: named(encode(to:)))
 public macro Encodable(
   options: CodableOptions = .default

--- a/Sources/CodableKit/CodingHooks.swift
+++ b/Sources/CodableKit/CodingHooks.swift
@@ -1,0 +1,57 @@
+//
+//  CodingHooks.swift
+//  CodableKit
+//
+//  Created by Wendell Wang on 2025/6/5.
+//
+
+/// Provides hooks for custom actions after decoding from a Decoder.
+public protocol DecodingHooks {
+  /// Called immediately after all properties are decoded.
+  ///
+  /// - Parameter decoder: The decoder instance used for decoding.
+  /// - Throws: Any error thrown from custom logic.
+  @inline(__always)
+  func didDecode(from decoder: any Decoder) throws
+}
+
+/// Provides hooks for custom actions before and after encoding to an Encoder.
+public protocol EncodingHooks {
+  /// Called immediately before any property is encoded.
+  ///
+  /// - Parameter encoder: The encoder instance used for encoding.
+  /// - Throws: Any error thrown from custom logic.
+  @inline(__always)
+  func willEncode(to encoder: any Encoder) throws
+
+  /// Called immediately after all properties are encoded.
+  ///
+  /// - Parameter encoder: The encoder instance used for encoding.
+  /// - Throws: Any error thrown from custom logic.
+  @inline(__always)
+  func didEncode(to encoder: any Encoder) throws
+}
+
+/// Composite protocol that includes all encoding and decoding hooks.
+public typealias CodableHooks = DecodingHooks & EncodingHooks
+
+// MARK: - Default Implementations
+
+extension DecodingHooks {
+  @inline(__always)
+  public func didDecode(from decoder: any Decoder) throws {
+    // Default: do nothing
+  }
+}
+
+extension EncodingHooks {
+  @inline(__always)
+  public func willEncode(to encoder: any Encoder) throws {
+    // Default: do nothing
+  }
+
+  @inline(__always)
+  public func didEncode(to encoder: any Encoder) throws {
+    // Default: do nothing
+  }
+}

--- a/Sources/CodableKitMacros/CodableMacro.swift
+++ b/Sources/CodableKitMacros/CodableMacro.swift
@@ -269,6 +269,8 @@ extension CodableMacro {
           "try super.init(from: decoder)"
         }
       }
+
+      "try didDecode(from: decoder)"
     }
   }
 
@@ -290,6 +292,8 @@ extension CodableMacro {
         effectSpecifiers: .init(throwsClause: .init(throwsSpecifier: .keyword(.throws)))
       )
     ) {
+      "try willEncode(to: encoder)"
+
       CodeBlockItemSyntax(item: .decl(core.genEncodeContainerDecl()))
       for property in properties where property.isNormal {
         CodeBlockItemSyntax(
@@ -332,6 +336,8 @@ extension CodableMacro {
       if hasSuper, !codableOptions.contains(.skipSuperCoding) {
         "try super.encode(to: encoder)"
       }
+
+      "try didEncode(to: encoder)"
     }
   }
 }

--- a/Sources/CodableKitMacros/CodeGenCore+GenDecode.swift
+++ b/Sources/CodableKitMacros/CodeGenCore+GenDecode.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 // MARK: JSONDecoder
 
@@ -31,7 +32,7 @@ extension CodeGenCore {
         leftParen: .leftParenToken(),
         rightParen: .rightParenToken()
       ) {
-        LabeledExprSyntax(expression: genTypeExpr(typeName: "\(type)"))
+        LabeledExprSyntax(expression: genChaningMembers("\(type)", "self"))
         LabeledExprSyntax(
           label: "from",
           expression: DeclReferenceExprSyntax(baseName: .identifier("\(data)"))
@@ -87,7 +88,7 @@ extension CodeGenCore {
       ) {
         LabeledExprSyntax(
           label: "keyedBy",
-          expression: genTypeExpr(typeName: codingKeysName)
+          expression: genChaningMembers(codingKeysName, "self")
         )
       }
     )
@@ -120,8 +121,11 @@ extension CodeGenCore {
       leftParen: .leftParenToken(),
       rightParen: .rightParenToken()
     ) {
-      LabeledExprSyntax(expression: genTypeExpr(typeName: "\(type)"))
-      LabeledExprSyntax(label: "forKey", expression: genDotExpr(name: "\(patternName)"))
+      LabeledExprSyntax(expression: genChaningMembers("\(type)", "self"))
+      LabeledExprSyntax(
+        label: "forKey",
+        expression: genChaningMembers("\(patternName)")
+      )
     }
 
     guard useDefaultOnFailure else {
@@ -303,7 +307,7 @@ extension CodeGenCore {
                   ) {
                     LabeledExprSyntax(
                       label: "using",
-                      expression: genDotExpr(name: "utf8")
+                      expression: genChaningMembers("utf8")
                     )
                   }
                 )
@@ -384,7 +388,7 @@ extension CodeGenCore {
         ) {
           LabeledExprSyntax(
             leadingTrivia: .spaces(2),
-            expression: genTypeExpr(typeName: "\(type)"),
+            expression: genChaningMembers("\(type)", "self"),
             trailingComma: .commaToken(trailingTrivia: .newline)
           )
           LabeledExprSyntax(

--- a/Sources/CodableKitMacros/CodeGenCore+GenEncode.swift
+++ b/Sources/CodableKitMacros/CodeGenCore+GenEncode.swift
@@ -71,7 +71,7 @@ extension CodeGenCore {
     ) {
       LabeledExprSyntax(
         label: "keyedBy",
-        expression: genTypeExpr(typeName: codingKeysName)
+        expression: genChaningMembers(codingKeysName, "self")
       )
     }
 
@@ -117,7 +117,7 @@ extension CodeGenCore {
           rightParen: .rightParenToken()
         ) {
           LabeledExprSyntax(expression: DeclReferenceExprSyntax(baseName: .identifier("\(patternName)")))
-          LabeledExprSyntax(label: "forKey", expression: genDotExpr(name: "\(key)"))
+          LabeledExprSyntax(label: "forKey", expression: genChaningMembers("\(key)"))
         }
       )
     )
@@ -166,7 +166,7 @@ extension CodeGenCore {
                       label: "data",
                       expression: DeclReferenceExprSyntax(baseName: .identifier("\(rawDataName)"))
                     )
-                    LabeledExprSyntax(label: "encoding", expression: genDotExpr(name: "utf8"))
+                    LabeledExprSyntax(label: "encoding", expression: genChaningMembers("utf8"))
                   }
                 )
               )

--- a/Tests/CodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -35,14 +35,17 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -83,14 +86,17 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -132,14 +138,17 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -180,14 +189,17 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -231,14 +243,17 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -283,15 +298,18 @@ final class CodableKitTestsForSubClass: XCTestCase {
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -338,14 +356,17 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -396,14 +417,17 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -467,9 +491,11 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -487,6 +513,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -551,9 +578,11 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -571,6 +600,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -629,9 +659,11 @@ final class CodableKitTestsForSubClass: XCTestCase {
               room = Room(id: UUID(), name: "Hello")
             }
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -649,6 +681,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -713,9 +746,11 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -733,6 +768,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -791,9 +827,11 @@ final class CodableKitTestsForSubClass: XCTestCase {
               room = Room(id: UUID(), name: "Hello")
             }
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -811,6 +849,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -866,15 +905,18 @@ final class CodableKitTestsForSubClass: XCTestCase {
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -916,13 +958,16 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             super.init()
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/CodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class.swift
@@ -33,13 +33,16 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -78,13 +81,16 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -125,13 +131,16 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -171,13 +180,16 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -220,13 +232,16 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -270,14 +285,17 @@ final class CodableKitTestsForClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
+            try didEncode(to: encoder)
           }
         }
 
@@ -323,13 +341,16 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -379,13 +400,16 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -448,9 +472,11 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -467,6 +493,7 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -530,9 +557,11 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -549,6 +578,7 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -606,9 +636,11 @@ final class CodableKitTestsForClass: XCTestCase {
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -625,6 +657,7 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -688,9 +721,11 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -707,6 +742,7 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -764,9 +800,11 @@ final class CodableKitTestsForClass: XCTestCase {
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -783,6 +821,7 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -837,14 +876,17 @@ final class CodableKitTestsForClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
+            try didEncode(to: encoder)
           }
         }
 
@@ -885,13 +927,16 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/CodableKitTests/CodableMacroTests+diagnostics.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+diagnostics.swift
@@ -59,10 +59,12 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           var ignored: String = "Hello World"
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -78,6 +80,7 @@ final class CodableKitDiagnosticsTests: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -109,10 +112,12 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           static let staticProperty = "Hello World"
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -128,6 +133,7 @@ final class CodableKitDiagnosticsTests: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -162,10 +168,12 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -181,6 +189,7 @@ final class CodableKitDiagnosticsTests: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -218,10 +227,12 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -237,6 +248,7 @@ final class CodableKitDiagnosticsTests: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -270,10 +282,12 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           static var address: String = "A"
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -289,6 +303,7 @@ final class CodableKitDiagnosticsTests: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,

--- a/Tests/CodableKitTests/CodableMacroTests+struct.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+struct.swift
@@ -30,10 +30,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -49,6 +51,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -76,10 +79,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -95,6 +100,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -123,10 +129,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -142,6 +150,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -169,10 +178,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           var age: Int? = 24
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -188,6 +199,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -218,10 +230,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           let thisPropertyWillBeIgnored: String
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -237,6 +251,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -267,11 +282,13 @@ final class CodableKitTestsForStruct: XCTestCase {
           let explicitNil: String?
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
+            try didEncode(to: encoder)
           }
         }
 
@@ -289,6 +306,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -321,10 +339,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -340,6 +360,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -377,10 +398,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -396,6 +419,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -434,6 +458,7 @@ final class CodableKitTestsForStruct: XCTestCase {
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -450,6 +475,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -478,6 +504,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -516,6 +543,7 @@ final class CodableKitTestsForStruct: XCTestCase {
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -532,6 +560,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -560,6 +589,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -598,6 +628,7 @@ final class CodableKitTestsForStruct: XCTestCase {
           var room: Room = Room(id: UUID(), name: "Hello")
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -614,6 +645,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -636,6 +668,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -674,6 +707,7 @@ final class CodableKitTestsForStruct: XCTestCase {
           var room: Room?
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -690,6 +724,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -712,6 +747,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             } else {
               room = nil
             }
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -750,6 +786,7 @@ final class CodableKitTestsForStruct: XCTestCase {
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -766,6 +803,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -794,6 +832,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -832,6 +871,7 @@ final class CodableKitTestsForStruct: XCTestCase {
           var room: Room = Room(id: UUID(), name: "Hello")
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -848,6 +888,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -876,6 +917,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -916,11 +958,13 @@ final class CodableKitTestsForStruct: XCTestCase {
           var role: Role = .unknown
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
+            try didEncode(to: encoder)
           }
         }
 
@@ -938,6 +982,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
+            try didDecode(from: decoder)
           }
         }
         """,

--- a/Tests/DecodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -35,6 +35,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -75,6 +76,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -116,6 +118,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -156,6 +159,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -199,6 +203,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -243,6 +248,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -289,6 +295,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -339,6 +346,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -402,6 +410,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -466,6 +475,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -524,6 +534,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               room = Room(id: UUID(), name: "Hello")
             }
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -579,6 +590,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
             try super.init(from: decoder)
+            try didDecode(from: decoder)
           }
         }
 
@@ -620,6 +632,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             super.init()
+            try didDecode(from: decoder)
           }
         }
 

--- a/Tests/DecodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+class.swift
@@ -33,6 +33,7 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
 
@@ -71,6 +72,7 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
 
@@ -111,6 +113,7 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
 
@@ -150,6 +153,7 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
 
@@ -192,6 +196,7 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
 
@@ -235,6 +240,7 @@ final class CodableKitTestsForClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
+            try didDecode(from: decoder)
           }
         }
 
@@ -280,6 +286,7 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
 
@@ -329,6 +336,7 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
 
@@ -391,6 +399,7 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
         }
 
@@ -454,6 +463,7 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
         }
 
@@ -511,6 +521,7 @@ final class CodableKitTestsForClass: XCTestCase {
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
+            try didDecode(from: decoder)
           }
         }
 
@@ -565,6 +576,7 @@ final class CodableKitTestsForClass: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
+            try didDecode(from: decoder)
           }
         }
 
@@ -605,6 +617,7 @@ final class CodableKitTestsForClass: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
 

--- a/Tests/DecodableKitTests/CodableMacroTests+diagnostics.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+diagnostics.swift
@@ -72,6 +72,7 @@ final class CodableKitDiagnosticsTests: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -115,6 +116,7 @@ final class CodableKitDiagnosticsTests: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -161,6 +163,7 @@ final class CodableKitDiagnosticsTests: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -210,6 +213,7 @@ final class CodableKitDiagnosticsTests: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -255,6 +259,7 @@ final class CodableKitDiagnosticsTests: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,

--- a/Tests/DecodableKitTests/CodableMacroTests+struct.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+struct.swift
@@ -42,6 +42,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -81,6 +82,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -121,6 +123,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -160,6 +163,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -202,6 +206,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -246,6 +251,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -290,6 +296,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -339,6 +346,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -402,6 +410,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -465,6 +474,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -522,6 +532,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
+            try didDecode(from: decoder)
           }
         }
         """,
@@ -576,6 +587,7 @@ final class CodableKitTestsForStruct: XCTestCase {
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
+            try didDecode(from: decoder)
           }
         }
         """,

--- a/Tests/EncodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -30,11 +30,13 @@ final class CodableKitTestsForSubClass: XCTestCase {
           let age: Int
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -70,11 +72,13 @@ final class CodableKitTestsForSubClass: XCTestCase {
           var age: Int = 24
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -111,11 +115,13 @@ final class CodableKitTestsForSubClass: XCTestCase {
           var age: Int = 24
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -151,11 +157,13 @@ final class CodableKitTestsForSubClass: XCTestCase {
           var age: Int? = 24
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -194,11 +202,13 @@ final class CodableKitTestsForSubClass: XCTestCase {
           let thisPropertyWillBeIgnored: String
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -237,12 +247,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           let explicitNil: String?
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -284,11 +296,13 @@ final class CodableKitTestsForSubClass: XCTestCase {
           let age: Int
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -334,11 +348,13 @@ final class CodableKitTestsForSubClass: XCTestCase {
           let age: Int
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -385,6 +401,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
           let room: Room
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -402,6 +419,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -449,6 +467,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
           let room: Room
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -466,6 +485,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -513,6 +533,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
           var room: Room = Room(id: UUID(), name: "Hello")
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -530,6 +551,7 @@ final class CodableKitTestsForSubClass: XCTestCase {
               )
             }
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -579,12 +601,14 @@ final class CodableKitTestsForSubClass: XCTestCase {
           var role: Role = .unknown
 
           public override func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
             try super.encode(to: encoder)
+            try didEncode(to: encoder)
           }
         }
 
@@ -621,10 +645,12 @@ final class CodableKitTestsForSubClass: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/EncodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+class.swift
@@ -29,10 +29,12 @@ final class CodableKitTestsForClass: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -67,10 +69,12 @@ final class CodableKitTestsForClass: XCTestCase {
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -107,10 +111,12 @@ final class CodableKitTestsForClass: XCTestCase {
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -146,10 +152,12 @@ final class CodableKitTestsForClass: XCTestCase {
           var age: Int? = 24
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -188,10 +196,12 @@ final class CodableKitTestsForClass: XCTestCase {
           let thisPropertyWillBeIgnored: String
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -230,11 +240,13 @@ final class CodableKitTestsForClass: XCTestCase {
           let explicitNil: String?
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
+            try didEncode(to: encoder)
           }
         }
 
@@ -276,10 +288,12 @@ final class CodableKitTestsForClass: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -325,10 +339,12 @@ final class CodableKitTestsForClass: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -375,6 +391,7 @@ final class CodableKitTestsForClass: XCTestCase {
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -391,6 +408,7 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -438,6 +456,7 @@ final class CodableKitTestsForClass: XCTestCase {
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -454,6 +473,7 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -501,6 +521,7 @@ final class CodableKitTestsForClass: XCTestCase {
           var room: Room = Room(id: UUID(), name: "Hello")
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -517,6 +538,7 @@ final class CodableKitTestsForClass: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -566,11 +588,13 @@ final class CodableKitTestsForClass: XCTestCase {
           var role: Role = .unknown
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
+            try didEncode(to: encoder)
           }
         }
 
@@ -607,10 +631,12 @@ final class CodableKitTestsForClass: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/EncodableKitTests/CodableMacroTests+diagnostics.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+diagnostics.swift
@@ -59,10 +59,12 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           var ignored: String = "Hello World"
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -102,10 +104,12 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           static let staticProperty = "Hello World"
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -148,10 +152,12 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -197,10 +203,12 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           }
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -242,10 +250,12 @@ final class CodableKitDiagnosticsTests: XCTestCase {
           static var address: String = "A"
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/EncodableKitTests/CodableMacroTests+struct.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+struct.swift
@@ -30,10 +30,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -69,10 +71,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -109,10 +113,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -148,10 +154,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           var age: Int? = 24
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -190,10 +198,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           let thisPropertyWillBeIgnored: String
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -232,11 +242,13 @@ final class CodableKitTestsForStruct: XCTestCase {
           let explicitNil: String?
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
+            try didEncode(to: encoder)
           }
         }
 
@@ -278,10 +290,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -327,10 +341,12 @@ final class CodableKitTestsForStruct: XCTestCase {
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
           }
         }
 
@@ -377,6 +393,7 @@ final class CodableKitTestsForStruct: XCTestCase {
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -393,6 +410,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -440,6 +458,7 @@ final class CodableKitTestsForStruct: XCTestCase {
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -456,6 +475,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -503,6 +523,7 @@ final class CodableKitTestsForStruct: XCTestCase {
           var room: Room = Room(id: UUID(), name: "Hello")
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
@@ -519,6 +540,7 @@ final class CodableKitTestsForStruct: XCTestCase {
                 )
               )
             }
+            try didEncode(to: encoder)
           }
         }
 
@@ -568,11 +590,13 @@ final class CodableKitTestsForStruct: XCTestCase {
           var role: Role = .unknown
 
           public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
+            try didEncode(to: encoder)
           }
         }
 


### PR DESCRIPTION
* Modified `Codable`, `Decodable`, and `Encodable` macros to include `CodableHooks` for custom actions during encoding and decoding. (`Sources/CodableKit/CodableKit.swift`, [[1]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L60-R60) [[2]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L105-R105) [[3]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L150-R150)
* Added `DecodingHooks` and `EncodingHooks` protocols for defining custom behavior after decoding and before/after encoding. Default implementations provided to allow optional usage. (`Sources/CodableKit/CodingHooks.swift`, [Sources/CodableKit/CodingHooks.swiftR1-R57](diffhunk://#diff-14c50bf4d29c386d05f19e0259988ef323c8cd004b8aad7423fe2e6b204c4ccbR1-R57))