### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
 
 name: Swift
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/WendellXY/CodableKit/security/code-scanning/1](https://github.com/WendellXY/CodableKit/security/code-scanning/1)

To fix this problem, we need to add a `permissions` block to restrict the GITHUB_TOKEN permissions to the minimum needed for this build and test workflow. The best place for this block is at the workflow root (just under `name: Swift` and before the `on:` block), so all jobs inherit these permissions. For a workflow that only builds and tests code, `contents: read` is usually sufficient and recommended as a minimal starting point. No changes to any actual job logic or workflow steps are required; just adding the permissions block in `.github/workflows/ci.yml` after the workflow name is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
