### PR TITLE
Feature: Literal Type Inference

### DIFF
--- a/Sources/CodableKitMacros/CodableProperty.swift
+++ b/Sources/CodableKitMacros/CodableProperty.swift
@@ -44,7 +44,7 @@ struct CodableProperty {
   ) {
     self.attributes = attributes
     self.declModifiers = declModifiers
-    self.name = binding.pattern
+    self.name = binding.pattern.trimmed
     self.type = binding.typeAnnotation?.type.trimmed ?? type.trimmed
     self.defaultValue = binding.initializer?.value
   }
@@ -62,7 +62,7 @@ struct CodableProperty {
   ) {
     self.attributes = attributes
     self.declModifiers = declModifiers
-    self.name = PatternSyntax(IdentifierPatternSyntax(identifier: caseElement.name))
+    self.name = PatternSyntax(IdentifierPatternSyntax(identifier: caseElement.name.trimmed))
     self.type = "Never"
     self.defaultValue = nil
   }

--- a/Tests/CodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -602,7 +602,7 @@ import Testing
       diagnostics: [
         .init(
           message: "Option '.useDefaultOnFailure' has no effect for non-optional property without a default value",
-          line: 11,
+          line: 8,
           column: 7,
           severity: .warning
         )
@@ -778,7 +778,7 @@ import Testing
       diagnostics: [
         .init(
           message: "Option '.useDefaultOnFailure' has no effect for non-optional property without a default value",
-          line: 11,
+          line: 8,
           column: 7,
           severity: .warning
         )

--- a/Tests/CodableKitTests/CodableMacroTests+diagnostics.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+diagnostics.swift
@@ -20,14 +20,14 @@ import Testing
       public struct User {
         let id: UUID
         let name: String
-        var age = 24
+        var age = genSomeThing()
       }
       """,
       expandedSource: """
         public struct User {
           let id: UUID
           let name: String
-          var age = 24
+          var age = genSomeThing()
         }
         """,
       diagnostics: [

--- a/Tests/CodableKitTests/TypeInferenceTests.swift
+++ b/Tests/CodableKitTests/TypeInferenceTests.swift
@@ -1,0 +1,65 @@
+//
+//  TypeInferenceTests.swift
+//  CodableKit
+//
+//  Created by Wendell Wang on 2025/9/5.
+//
+
+import CodableKitMacros
+import SwiftSyntaxMacrosTestSupport
+import Testing
+
+@Suite("Type Inference Tests")
+struct TypeInferenceTests {
+  @Test("Type Inference for literals")
+  func testTypeInferenceForLiterals() async throws {
+    assertMacro(
+      """
+      @Codable
+      public struct User {
+        var strLiteral = "Hello"
+        var intLiteral = 123
+        var doubleLiteral = 123.456
+        var boolLiteral = true
+      }
+      """,
+      expandedSource:
+        """
+        public struct User {
+          var strLiteral = "Hello"
+          var intLiteral = 123
+          var doubleLiteral = 123.456
+          var boolLiteral = true
+
+          public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(strLiteral , forKey: .strLiteral )
+            try container.encode(intLiteral , forKey: .intLiteral )
+            try container.encode(doubleLiteral , forKey: .doubleLiteral )
+            try container.encode(boolLiteral , forKey: .boolLiteral )
+            try didEncode(to: encoder)
+          }
+        }
+
+        extension User: Codable {
+          enum CodingKeys: String, CodingKey {
+            case strLiteral
+            case intLiteral
+            case doubleLiteral
+            case boolLiteral
+          }
+
+          public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            strLiteral  = try container.decodeIfPresent(String.self, forKey: .strLiteral ) ?? "Hello"
+            intLiteral  = try container.decodeIfPresent(Int.self, forKey: .intLiteral ) ?? 123
+            doubleLiteral  = try container.decodeIfPresent(Double.self, forKey: .doubleLiteral ) ?? 123.456
+            boolLiteral  = try container.decodeIfPresent(Bool.self, forKey: .boolLiteral ) ?? true
+            try didDecode(from: decoder)
+          }
+        }
+        """
+    )
+  }
+}

--- a/Tests/CodableKitTests/TypeInferenceTests.swift
+++ b/Tests/CodableKitTests/TypeInferenceTests.swift
@@ -21,6 +21,8 @@ struct TypeInferenceTests {
         var intLiteral = 123
         var doubleLiteral = 123.456
         var boolLiteral = true
+        var negativeIntLiteral = -123
+        var negativeDoubleLiteral = -123.456
       }
       """,
       expandedSource:
@@ -30,14 +32,18 @@ struct TypeInferenceTests {
           var intLiteral = 123
           var doubleLiteral = 123.456
           var boolLiteral = true
+          var negativeIntLiteral = -123
+          var negativeDoubleLiteral = -123.456
 
           public func encode(to encoder: any Encoder) throws {
             try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(strLiteral , forKey: .strLiteral )
-            try container.encode(intLiteral , forKey: .intLiteral )
-            try container.encode(doubleLiteral , forKey: .doubleLiteral )
-            try container.encode(boolLiteral , forKey: .boolLiteral )
+            try container.encode(strLiteral, forKey: .strLiteral)
+            try container.encode(intLiteral, forKey: .intLiteral)
+            try container.encode(doubleLiteral, forKey: .doubleLiteral)
+            try container.encode(boolLiteral, forKey: .boolLiteral)
+            try container.encode(negativeIntLiteral, forKey: .negativeIntLiteral)
+            try container.encode(negativeDoubleLiteral, forKey: .negativeDoubleLiteral)
             try didEncode(to: encoder)
           }
         }
@@ -48,14 +54,75 @@ struct TypeInferenceTests {
             case intLiteral
             case doubleLiteral
             case boolLiteral
+            case negativeIntLiteral
+            case negativeDoubleLiteral
           }
 
           public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            strLiteral  = try container.decodeIfPresent(String.self, forKey: .strLiteral ) ?? "Hello"
-            intLiteral  = try container.decodeIfPresent(Int.self, forKey: .intLiteral ) ?? 123
-            doubleLiteral  = try container.decodeIfPresent(Double.self, forKey: .doubleLiteral ) ?? 123.456
-            boolLiteral  = try container.decodeIfPresent(Bool.self, forKey: .boolLiteral ) ?? true
+            strLiteral = try container.decodeIfPresent(String.self, forKey: .strLiteral) ?? "Hello"
+            intLiteral = try container.decodeIfPresent(Int.self, forKey: .intLiteral) ?? 123
+            doubleLiteral = try container.decodeIfPresent(Double.self, forKey: .doubleLiteral) ?? 123.456
+            boolLiteral = try container.decodeIfPresent(Bool.self, forKey: .boolLiteral) ?? true
+            negativeIntLiteral = try container.decodeIfPresent(Int.self, forKey: .negativeIntLiteral) ?? -123
+            negativeDoubleLiteral = try container.decodeIfPresent(Double.self, forKey: .negativeDoubleLiteral) ?? -123.456
+            try didDecode(from: decoder)
+          }
+        }
+        """
+    )
+  }
+
+  @Test("Type Inference for arrays")
+  func testTypeInferenceForArrays() async throws {
+    assertMacro(
+      """
+      @Codable
+      public struct User {
+        var arrayLiteral = [1, 2, 3]
+        var stringArrayLiteral = ["Hello", "World"]
+        var boolArrayLiteral = [true, false]
+        var doubleArrayLiteral = [1.0, 2.0, 3.0]
+        var numberArrayLiteral = [1, 2.0, 3]
+      }
+      """,
+      expandedSource:
+        """
+        public struct User {
+          var arrayLiteral = [1, 2, 3]
+          var stringArrayLiteral = ["Hello", "World"]
+          var boolArrayLiteral = [true, false]
+          var doubleArrayLiteral = [1.0, 2.0, 3.0]
+          var numberArrayLiteral = [1, 2.0, 3]
+
+          public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(arrayLiteral, forKey: .arrayLiteral)
+            try container.encode(stringArrayLiteral, forKey: .stringArrayLiteral)
+            try container.encode(boolArrayLiteral, forKey: .boolArrayLiteral)
+            try container.encode(doubleArrayLiteral, forKey: .doubleArrayLiteral)
+            try container.encode(numberArrayLiteral, forKey: .numberArrayLiteral)
+            try didEncode(to: encoder)
+          }
+        }
+
+        extension User: Codable {
+          enum CodingKeys: String, CodingKey {
+            case arrayLiteral
+            case stringArrayLiteral
+            case boolArrayLiteral
+            case doubleArrayLiteral
+            case numberArrayLiteral
+          }
+
+          public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            arrayLiteral = try container.decodeIfPresent([Int].self, forKey: .arrayLiteral) ?? [1, 2, 3]
+            stringArrayLiteral = try container.decodeIfPresent([String].self, forKey: .stringArrayLiteral) ?? ["Hello", "World"]
+            boolArrayLiteral = try container.decodeIfPresent([Bool].self, forKey: .boolArrayLiteral) ?? [true, false]
+            doubleArrayLiteral = try container.decodeIfPresent([Double].self, forKey: .doubleArrayLiteral) ?? [1.0, 2.0, 3.0]
+            numberArrayLiteral = try container.decodeIfPresent([Double].self, forKey: .numberArrayLiteral) ?? [1, 2.0, 3]
             try didDecode(from: decoder)
           }
         }

--- a/Tests/DecodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -475,7 +475,7 @@ import Testing
       diagnostics: [
         .init(
           message: "Option '.useDefaultOnFailure' has no effect for non-optional property without a default value",
-          line: 11,
+          line: 8,
           column: 7,
           severity: .warning
         )

--- a/Tests/DecodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+class.swift
@@ -463,7 +463,7 @@ import Testing
       diagnostics: [
         .init(
           message: "Option '.useDefaultOnFailure' has no effect for non-optional property without a default value",
-          line: 11,
+          line: 8,
           column: 7,
           severity: .warning
         )

--- a/Tests/DecodableKitTests/CodableMacroTests+diagnostics.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+diagnostics.swift
@@ -21,14 +21,14 @@ import Testing
       public struct User {
         let id: UUID
         let name: String
-        var age = 24
+        var age = genSomeThing()
       }
       """,
       expandedSource: """
         public struct User {
           let id: UUID
           let name: String
-          var age = 24
+          var age = genSomeThing()
         }
         """,
       diagnostics: [

--- a/Tests/DecodableKitTests/CodableMacroTests+struct.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+struct.swift
@@ -465,7 +465,7 @@ import Testing
       diagnostics: [
         .init(
           message: "Option '.useDefaultOnFailure' has no effect for non-optional property without a default value",
-          line: 11,
+          line: 8,
           column: 7,
           severity: .warning
         )

--- a/Tests/EncodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -485,7 +485,7 @@ import Testing
       diagnostics: [
         .init(
           message: "Option '.useDefaultOnFailure' has no effect for non-optional property without a default value",
-          line: 11,
+          line: 8,
           column: 7,
           severity: .warning
         )

--- a/Tests/EncodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+class.swift
@@ -473,7 +473,7 @@ import Testing
       diagnostics: [
         .init(
           message: "Option '.useDefaultOnFailure' has no effect for non-optional property without a default value",
-          line: 11,
+          line: 8,
           column: 7,
           severity: .warning
         )

--- a/Tests/EncodableKitTests/CodableMacroTests+diagnostics.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+diagnostics.swift
@@ -20,14 +20,14 @@ import Testing
       public struct User {
         let id: UUID
         let name: String
-        var age = 24
+        var age = genSomeThing()
       }
       """,
       expandedSource: """
         public struct User {
           let id: UUID
           let name: String
-          var age = 24
+          var age = genSomeThing()
         }
         """,
       diagnostics: [

--- a/Tests/EncodableKitTests/CodableMacroTests+struct.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+struct.swift
@@ -475,7 +475,7 @@ import Testing
       diagnostics: [
         .init(
           message: "Option '.useDefaultOnFailure' has no effect for non-optional property without a default value",
-          line: 11,
+          line: 8,
           column: 7,
           severity: .warning
         )


### PR DESCRIPTION
This pull request introduces type inference for properties in the `@Codable` macro, allowing automatic detection of types from literal initializers (such as strings, numbers, booleans, and arrays) when no explicit type annotation is present. It also updates diagnostics and tests to reflect this new behavior, ensuring accurate error reporting and validation. Additionally, minor improvements were made to property name handling and test diagnostics.

**Type Inference Improvements**
* Added a new `inferType` method to `CodableProperty` in `CodableKitMacros/CodableProperty.swift` to automatically infer types from literal initializers, supporting String, Int, Double, Bool, and homogeneous arrays of these types.
* Updated property extraction logic to use explicit type annotations, shared trailing annotations, or inferred types from initializers, skipping ignored properties without type annotations and emitting errors only when necessary.
* Added comprehensive unit tests in `TypeInferenceTests.swift` to verify type inference for literals and arrays.

**Property Name Handling**
* Improved property name extraction by trimming whitespace from binding patterns and enum case names in `CodableProperty`. [[1]](diffhunk://#diff-0591261f30ee950510ef2b840c34365f65c790d34a27e0a94f3e2863d975e59aL47-R47) [[2]](diffhunk://#diff-0591261f30ee950510ef2b840c34365f65c790d34a27e0a94f3e2863d975e59aL65-R65)

**Diagnostics and Test Updates**
* Updated diagnostics line numbers in various test files to reflect changes in code structure and ensure correct error reporting. [[1]](diffhunk://#diff-93cf0aa4e9834a8a655c15f333c8c5fe035e64c1e8149dda74cc33d5b69d6306L605-R605) [[2]](diffhunk://#diff-93cf0aa4e9834a8a655c15f333c8c5fe035e64c1e8149dda74cc33d5b69d6306L781-R781) [[3]](diffhunk://#diff-de9027bb3112f4245d7acedeed8e73933b24038bb9693b53143f6439fe3b5fccL478-R478) [[4]](diffhunk://#diff-6533d2326baa04aa4d566f82d37c5f631d486bddecbd35e256e04ffc87d8dcb2L466-R466) [[5]](diffhunk://#diff-94b69224380a85ca71c20956514ab60fb99debca28a17ac70ead29095b7bb00dL468-R468) [[6]](diffhunk://#diff-9662c63cd37423775f4be5ecbf8671a0bee1d894c679916e3911ddfca93a2d6fL488-R488) [[7]](diffhunk://#diff-d88f5a237bb1240c652995c4e32eb85cf53ac0fd2eef74c4a0e047f5628a747eL476-R476) [[8]](diffhunk://#diff-59e48f6edd4247e27fe415751f083083c4656fa534e2170c5b2c265d1faa1f8fL478-R478)
* Changed test cases to use more complex initializers (e.g., `genSomeThing()`) instead of simple literals for the `age` property, ensuring tests do not trigger type inference for non-literal initializers. [[1]](diffhunk://#diff-423e67b4a1fbb4c4ccdd05f64c635bef43d0c49937260421bd4d73e0afdc01c0L23-R30) [[2]](diffhunk://#diff-140cfed957cb6784bbf4540c93de0537d620bcc0173326859a2ede9645f82a10L24-R31) [[3]](diffhunk://#diff-8921566a70c9b6d195aedfd80fcdfd3f91c32dc668f02d45b81b04bf43f30094L23-R30)

These changes collectively enhance the usability and robustness of the `@Codable` macro by supporting type inference for common literal initializers and improving test coverage and diagnostics.