### PR TITLE
Fix: The lossy coding is missing the encode field code.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,7 @@ let package = Package(
     .testTarget(
       name: "CodableKitTests",
       dependencies: [
+        "CodableKit",
         "CodableKitShared",
         "CodableKitMacros",
         .product(name: "SwiftSyntax", package: "swift-syntax"),
@@ -52,6 +53,7 @@ let package = Package(
     .testTarget(
       name: "DecodableKitTests",
       dependencies: [
+        "CodableKit",
         "CodableKitShared",
         "CodableKitMacros",
         .product(name: "SwiftSyntax", package: "swift-syntax"),
@@ -61,6 +63,7 @@ let package = Package(
     .testTarget(
       name: "EncodableKitTests",
       dependencies: [
+        "CodableKit",
         "CodableKitShared",
         "CodableKitMacros",
         .product(name: "SwiftSyntax", package: "swift-syntax"),

--- a/Sources/CodableKitMacros/NamespaceNode.swift
+++ b/Sources/CodableKitMacros/NamespaceNode.swift
@@ -619,6 +619,26 @@ extension NamespaceNode {
         )
       })
 
+    // Encode lossy properties normally (lossy is decode-only). Skip when also using transcodeRawString.
+    for property in properties
+    where property.options.contains(.lossy)
+      && !property.options.contains(.transcodeRawString) && !property.ignored
+    {
+      result.append(
+        CodeBlockItemSyntax(
+          item: .expr(
+            CodeGenCore.genContainerEncodeExpr(
+              containerName: containerName,
+              key: property.name,
+              patternName: property.name,
+              isOptional: property.isOptional,
+              explicitNil: property.options.contains(.explicitNil)
+            )
+          )
+        )
+      )
+    }
+
     // Encode as raw JSON string (transcoding). For optionals without `.explicitNil`, omit the key when nil.
     for property in properties where property.options.contains(.transcodeRawString) && !property.ignored {
       if property.isOptional && !property.options.contains(.explicitNil) {

--- a/Tests/CodableKitTests/CodableMacroTests+lossy.data.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+lossy.data.swift
@@ -1,0 +1,86 @@
+//
+//  CodableMacroTests+lossy.data.swift
+//  CodableKitTests
+//
+//  Runtime behavior tests for lossy decoding
+//
+
+import CodableKit
+import Foundation
+import Testing
+
+// Top-level test models (local types cannot have attached macros)
+struct LossyItem: Codable, Equatable { let id: Int }
+
+@Codable
+struct LossyArrayModel {
+  @CodableKey(options: .lossy)
+  var items: [LossyItem]
+}
+
+@Codable
+struct LossyOptionalSetModel {
+  @CodableKey(options: .lossy)
+  var tags: Set<String>?
+}
+
+@Codable
+struct LossyDefaultModel {
+  @CodableKey(options: [.lossy, .useDefaultOnFailure])
+  var items: [LossyItem] = [LossyItem(id: 7)]
+}
+
+@Codable
+struct LossyTranscodeModel {
+  @CodableKey(options: [.lossy, .transcodeRawString])
+  var values: [Int]
+}
+
+@Codable
+struct LossySafeTranscodeModel {
+  @CodableKey(options: [.lossy, .safeTranscodeRawString])
+  var values: [Int] = [1, 2]
+}
+
+@Suite struct LossyRuntimeTests {
+  @Test func lossyArray_dropsInvalidElements() throws {
+    let json = #"{"items":[{"id":1},{"id":"oops"},{"id":3},{"bad":true},4,{"id":5}] }"#
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LossyArrayModel.self, from: data)
+    #expect(decoded.items == [LossyItem(id: 1), LossyItem(id: 3), LossyItem(id: 5)])
+  }
+
+  @Test func lossySet_optional_missingKey_isNil() throws {
+    let json = #"{}"#
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LossyOptionalSetModel.self, from: data)
+    #expect(decoded.tags == nil)
+  }
+
+  @Test func lossyArray_withDefault_and_useDefaultOnFailure() throws {
+    // Non-array type for items → falls back to default due to .useDefaultOnFailure
+    let json = #"{"items": 123}"#
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LossyDefaultModel.self, from: data)
+    #expect(decoded.items == [LossyItem(id: 7)])
+  }
+
+  @Test func lossy_transcodeRawString_combined() throws {
+    // values is a JSON string with mixed valid/invalid entries
+    let embedded = #"[{\"id\":1},2,3,\"oops\",4]"#
+    let payload = #"{"values":"\#(embedded)"}"#
+    let data = payload.data(using: .utf8)!
+
+    // Note: Our lossy path expects element to be Int; non-ints will be dropped
+    let decoded = try JSONDecoder().decode(LossyTranscodeModel.self, from: data)
+    #expect(decoded.values == [2, 3, 4])
+  }
+
+  @Test func lossy_safeTranscodeRawString_withDefault() throws {
+    // Missing/invalid string should fall back to default
+    let payload = #"{"values": null}"#
+    let data = payload.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LossySafeTranscodeModel.self, from: data)
+    #expect(decoded.values == [1, 2])
+  }
+}

--- a/Tests/EncodableKitTests/CodableMacroTests+lossy.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+lossy.swift
@@ -31,8 +31,8 @@ import Testing
           public func encode(to encoder: any Encoder) throws {
             try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
-            container.encode(values, forKey: .values)
-            container.encode(values2, forKey: .values2)
+            try container.encode(values, forKey: .values)
+            try container.encode(values2, forKey: .values2)
             try didEncode(to: encoder)
           }
         }
@@ -59,11 +59,11 @@ import Testing
       expandedSource: """
         public struct Model {
           let values: [String]?
-        
+
           public func encode(to encoder: any Encoder) throws {
             try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
-            container.encode(values, forKey: .values)
+            try container.encodeIfPresent(values, forKey: .values)
             try didEncode(to: encoder)
           }
         }
@@ -93,7 +93,7 @@ import Testing
           public func encode(to encoder: any Encoder) throws {
             try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
-            container.encode(values, forKey: .values)
+            try container.encode(values, forKey: .values)
             try didEncode(to: encoder)
           }
         }
@@ -123,7 +123,7 @@ import Testing
           public func encode(to encoder: any Encoder) throws {
             try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
-            container.encode(ids, forKey: .ids)
+            try container.encodeIfPresent(ids, forKey: .ids)
             try didEncode(to: encoder)
           }
         }
@@ -149,7 +149,7 @@ import Testing
       expandedSource: """
         public struct Model {
           let values: [Int]
-        
+
           public func encode(to encoder: any Encoder) throws {
             try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)

--- a/Tests/EncodableKitTests/CodableMacroTests+lossy.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+lossy.swift
@@ -1,0 +1,223 @@
+//
+//  CodableMacroTests+lossy.swift
+//  CodableKitTests
+//
+//  Created by Assistant on 2025/9/5.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import Testing
+
+@Suite struct CodableKitLossyEncodeTests {
+  @Test func lossyArray_nonOptional_noDefault() throws {
+    assertMacro(
+      """
+      @Encodable
+      public struct Model {
+        @CodableKey(options: .lossy)
+        let values: [Int]
+        @CodableKey(options: .lossy)
+        let values2: Array<String>
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          let values: [Int]
+          let values2: Array<String>
+
+          public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            container.encode(values, forKey: .values)
+            container.encode(values2, forKey: .values2)
+            try didEncode(to: encoder)
+          }
+        }
+
+        extension Model: Encodable {
+          enum CodingKeys: String, CodingKey {
+            case values
+            case values2
+          }
+        }
+        """
+    )
+  }
+
+  @Test func lossyArray_optional() throws {
+    assertMacro(
+      """
+      @Encodable
+      public struct Model {
+        @CodableKey(options: .lossy)
+        let values: [String]?
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          let values: [String]?
+        
+          public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            container.encode(values, forKey: .values)
+            try didEncode(to: encoder)
+          }
+        }
+
+        extension Model: Encodable {
+          enum CodingKeys: String, CodingKey {
+            case values
+          }
+        }
+        """
+    )
+  }
+
+  @Test func lossyArray_nonOptional_withDefault_and_useDefaultOnFailure() throws {
+    assertMacro(
+      """
+      @Encodable
+      public struct Model {
+        @CodableKey(options: [.lossy, .useDefaultOnFailure])
+        var values: [Int] = [1, 2]
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          var values: [Int] = [1, 2]
+
+          public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            container.encode(values, forKey: .values)
+            try didEncode(to: encoder)
+          }
+        }
+
+        extension Model: Encodable {
+          enum CodingKeys: String, CodingKey {
+            case values
+          }
+        }
+        """
+    )
+  }
+
+  @Test func lossySet_optional() throws {
+    assertMacro(
+      """
+      @Encodable
+      public struct Model {
+        @CodableKey(options: .lossy)
+        let ids: Set<Int>?
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          let ids: Set<Int>?
+
+          public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            container.encode(ids, forKey: .ids)
+            try didEncode(to: encoder)
+          }
+        }
+
+        extension Model: Encodable {
+          enum CodingKeys: String, CodingKey {
+            case ids
+          }
+        }
+        """
+    )
+  }
+
+  @Test func lossy_combined_with_transcodeRawString() throws {
+    assertMacro(
+      """
+      @Encodable
+      public struct Model {
+        @CodableKey(options: [.lossy, .transcodeRawString])
+        let values: [Int]
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          let values: [Int]
+        
+          public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            let __ckEncoder = JSONEncoder()
+            let valuesRawData = try __ckEncoder.encode(values)
+            if let valuesRawString = String(data: valuesRawData, encoding: .utf8) {
+              try container.encode(valuesRawString, forKey: .values)
+            } else {
+              throw EncodingError.invalidValue(
+                valuesRawData,
+                EncodingError.Context(
+                  codingPath: [CodingKeys.values],
+                  debugDescription: "Failed to transcode raw data to string"
+                )
+              )
+            }
+            try didEncode(to: encoder)
+          }
+        }
+
+        extension Model: Encodable {
+          enum CodingKeys: String, CodingKey {
+            case values
+          }
+        }
+        """
+    )
+  }
+
+  @Test func lossy_combined_with_safeTranscodeRawString() throws {
+    assertMacro(
+      """
+      @Encodable
+      public struct Model {
+        @CodableKey(options: [.lossy, .safeTranscodeRawString])
+        var values: [Int] = [1, 2]
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          var values: [Int] = [1, 2]
+
+          public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            let __ckEncoder = JSONEncoder()
+            let valuesRawData = try __ckEncoder.encode(values)
+            if let valuesRawString = String(data: valuesRawData, encoding: .utf8) {
+              try container.encode(valuesRawString, forKey: .values)
+            } else {
+              throw EncodingError.invalidValue(
+                valuesRawData,
+                EncodingError.Context(
+                  codingPath: [CodingKeys.values],
+                  debugDescription: "Failed to transcode raw data to string"
+                )
+              )
+            }
+            try didEncode(to: encoder)
+          }
+        }
+
+        extension Model: Encodable {
+          enum CodingKeys: String, CodingKey {
+            case values
+          }
+        }
+        """
+    )
+  }
+}


### PR DESCRIPTION
This pull request adds support for lossy encoding in the `@Encodable` macro, ensuring that properties marked with the `.lossy` option are encoded using standard encoding logic. It also introduces comprehensive runtime and macro expansion tests for lossy decoding and encoding, covering various combinations of options such as `.lossy`, `.useDefaultOnFailure`, and `.transcodeRawString`. Additionally, it updates the package manifest to ensure all test targets depend on `CodableKit`, enabling them to use shared functionality.

**Lossy encoding support:**

* Updated `NamespaceNode.swift` to encode properties marked with `.lossy` using standard encoding logic, except when combined with `.transcodeRawString`. This ensures lossy properties are handled correctly during encoding.

**Testing improvements:**

* Added new runtime tests in `CodableMacroTests+lossy.data.swift` to validate lossy decoding behavior, including dropping invalid elements, handling optionals, using defaults, and combining with transcode options.
* Introduced macro expansion tests in `CodableMacroTests+lossy.swift` to verify that the macro generates correct encoding logic for lossy properties under various scenarios.

**Package manifest updates:**

* Updated `Package.swift` to add `CodableKit` as a dependency for `CodableKitTests`, `DecodableKitTests`, and `EncodableKitTests`, ensuring consistent access to core functionality in all test targets. [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR46) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR56) [[3]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR66)