### PR TITLE
Feature: Lossy Coding for Dictionary

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ This roadmap outlines the major priorities and phased delivery plan for CodableK
 - Strong test coverage (snapshots + behavior) and CI signal
 
 ## Milestones
-- 1.5.x (In review): Phase 1 — correctness & stability (PRs #10, #11)
+- 1.5.x: Phase 1 — correctness & stability (PRs #10, #11)
 - 1.6.x: Phase 2 — ergonomics & resilience
 - 1.7.x: Phase 3 — expressiveness & conventions
 - 1.8.x: Phase 4 — docs, performance, CI

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ This roadmap outlines the major priorities and phased delivery plan for CodableK
     - Default/optional behaviors still respected (including `.useDefaultOnFailure`)
     - Works with `Set<T>` (deduplication preserved)
     - Composes with `.transcodeRawString` and `.safeTranscodeRawString` (decode lossy from transcoded payload)
-- [ ] Lossy decoding for dictionaries (`.lossy`)
+- [x] Lossy decoding for dictionaries (`.lossy`)
   - Acceptance:
     - Gracefully drop invalid entries and decode valid key/value pairs
 - Size-limit guard for raw-string transcode decoding

--- a/Sources/CodableKit/LossyDictionary.swift
+++ b/Sources/CodableKit/LossyDictionary.swift
@@ -1,0 +1,71 @@
+//
+//  LossyDictionary.swift
+//  CodableKit
+//
+//  Created by Assistant on 2025/9/6.
+//
+
+import Foundation
+
+/// A wrapper that decodes a dictionary in a "lossy" way:
+/// - Skips entries whose value fails to decode
+/// - Skips keys that cannot be converted to the expected `Key` type
+///
+/// Notes:
+/// - JSON object keys are strings. This wrapper requires `Key` to be
+///   `LosslessStringConvertible` so keys can be constructed from the raw
+///   JSON string key. Typical keys like `String` and `Int` are supported.
+public struct LossyDictionary<Key, Value>: Decodable where Key: LosslessStringConvertible & Hashable, Value: Decodable {
+  public var elements: [Key: Value] = [:]
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: AnyCodingKey.self)
+    var result: [Key: Value] = [:]
+    for codingKey in container.allKeys {
+      guard let key = Key(codingKey.stringValue) else { continue }
+      do {
+        let value = try container.decode(Value.self, forKey: codingKey)
+        result[key] = value
+      } catch {
+        // Skip invalid values
+        continue
+      }
+    }
+    self.elements = result
+  }
+
+  private struct AnyCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+    init?(stringValue: String) {
+      self.stringValue = stringValue
+      self.intValue = Int(stringValue)
+    }
+    init?(intValue: Int) {
+      self.intValue = intValue
+      self.stringValue = String(intValue)
+    }
+  }
+}
+
+extension LossyDictionary: Sendable where Key: Sendable, Value: Sendable {}
+extension LossyDictionary: Equatable where Value: Equatable {}
+extension LossyDictionary: Hashable where Value: Hashable {}
+
+extension LossyDictionary: ExpressibleByDictionaryLiteral {
+  public init(dictionaryLiteral elements: (Key, Value)...) {
+    self.elements = Dictionary(uniqueKeysWithValues: elements)
+  }
+}
+
+extension LossyDictionary: CustomStringConvertible {
+  public var description: String {
+    let pairs = elements.map { "\($0): \($1)" }.joined(separator: ", ")
+    return "LossyDictionary(\(pairs))"
+  }
+}
+
+extension LossyDictionary: CustomDebugStringConvertible {
+  public var debugDescription: String { description }
+}
+

--- a/Sources/CodableKitMacros/CodeGenCore.swift
+++ b/Sources/CodableKitMacros/CodeGenCore.swift
@@ -360,9 +360,11 @@ extension CodeGenCore {
         context.diagnose(diag)
       }
 
-      // Warn on `.lossy` used on non-collection type
-      if property.options.contains(.lossy) && !(property.isArrayType || property.isSetType) {
-        let message = "Option '.lossy' currently only supports Array<T> or Set<T> properties"
+      // Warn on `.lossy` used on unsupported type
+      if property.options.contains(.lossy)
+        && !(property.isArrayType || property.isSetType || property.isDictionaryType)
+      {
+        let message = "Option '.lossy' supports Array<T>, Set<T>, or Dictionary<K, V> properties"
         let diag = Diagnostic(
           node: Syntax(property.name), message: SimpleDiagnosticMessage(message: message, severity: .warning))
         context.diagnose(diag)

--- a/Sources/CodableKitMacros/NamespaceNode+Decode.swift
+++ b/Sources/CodableKitMacros/NamespaceNode+Decode.swift
@@ -99,36 +99,37 @@ extension NamespaceNode {
         )
 
         // if !rawString.isEmpty, let rawData = rawString.data(using: .utf8) { ... } else { throw or assign default }
-        let lossyType: TypeSyntax = {
-          if isDict, let dict = dictTypes {
-            return TypeSyntax(
-              IdentifierTypeSyntax(
-                name: .identifier("LossyDictionary"),
-                genericArgumentClause: GenericArgumentClauseSyntax(
-                  leftAngle: .leftAngleToken(),
-                  arguments: GenericArgumentListSyntax([
-                    .init(argument: dict.key, trailingComma: .commaToken(trailingTrivia: .spaces(1))),
-                    .init(argument: dict.value),
-                  ]),
-                  rightAngle: .rightAngleToken()
-                )
+        let lossyType: TypeSyntax
+        if isDict, let dict = dictTypes {
+          lossyType = TypeSyntax(
+            IdentifierTypeSyntax(
+              name: .identifier("LossyDictionary"),
+              genericArgumentClause: GenericArgumentClauseSyntax(
+                leftAngle: .leftAngleToken(),
+                arguments: GenericArgumentListSyntax([
+                  .init(argument: dict.key, trailingComma: .commaToken(trailingTrivia: .spaces(1))),
+                  .init(argument: dict.value),
+                ]),
+                rightAngle: .rightAngleToken()
               )
             )
-          } else {
-            return TypeSyntax(
-              IdentifierTypeSyntax(
-                name: .identifier("LossyArray"),
-                genericArgumentClause: GenericArgumentClauseSyntax(
-                  leftAngle: .leftAngleToken(),
-                  arguments: GenericArgumentListSyntax([
-                    .init(argument: elementType!)
-                  ]),
-                  rightAngle: .rightAngleToken()
-                )
+          )
+        } else if let elementType {
+          lossyType = TypeSyntax(
+            IdentifierTypeSyntax(
+              name: .identifier("LossyArray"),
+              genericArgumentClause: GenericArgumentClauseSyntax(
+                leftAngle: .leftAngleToken(),
+                arguments: GenericArgumentListSyntax([
+                  .init(argument: elementType)
+                ]),
+                rightAngle: .rightAngleToken()
               )
             )
-          }
-        }()
+          )
+        } else {
+          continue
+        }
 
         result.append(
           CodeBlockItemSyntax(
@@ -281,36 +282,37 @@ extension NamespaceNode {
         continue
       }
 
-      let lossyType: TypeSyntax = {
-        if isDict, let dict = dictTypes {
-          return TypeSyntax(
-            IdentifierTypeSyntax(
-              name: .identifier("LossyDictionary"),
-              genericArgumentClause: GenericArgumentClauseSyntax(
-                leftAngle: .leftAngleToken(),
-                arguments: GenericArgumentListSyntax([
-                  .init(argument: dict.key, trailingComma: .commaToken(trailingTrivia: .spaces(1))),
-                  .init(argument: dict.value),
-                ]),
-                rightAngle: .rightAngleToken()
-              )
+      let lossyType: TypeSyntax
+      if isDict, let dict = dictTypes {
+        lossyType = TypeSyntax(
+          IdentifierTypeSyntax(
+            name: .identifier("LossyDictionary"),
+            genericArgumentClause: GenericArgumentClauseSyntax(
+              leftAngle: .leftAngleToken(),
+              arguments: GenericArgumentListSyntax([
+                .init(argument: dict.key, trailingComma: .commaToken(trailingTrivia: .spaces(1))),
+                .init(argument: dict.value),
+              ]),
+              rightAngle: .rightAngleToken()
             )
           )
-        } else {
-          return TypeSyntax(
-            IdentifierTypeSyntax(
-              name: .identifier("LossyArray"),
-              genericArgumentClause: GenericArgumentClauseSyntax(
-                leftAngle: .leftAngleToken(),
-                arguments: GenericArgumentListSyntax([
-                  .init(argument: elementType!)
-                ]),
-                rightAngle: .rightAngleToken()
-              )
+        )
+      } else if let elementType {
+        lossyType = TypeSyntax(
+          IdentifierTypeSyntax(
+            name: .identifier("LossyArray"),
+            genericArgumentClause: GenericArgumentClauseSyntax(
+              leftAngle: .leftAngleToken(),
+              arguments: GenericArgumentListSyntax([
+                .init(argument: elementType)
+              ]),
+              rightAngle: .rightAngleToken()
             )
           )
-        }
-      }()
+        )
+      } else {
+        continue
+      }
 
       let shouldUseDecodeIfPresent = property.isOptional || property.defaultValue != nil
 

--- a/Sources/CodableKitShared/CodableKeyOptions.swift
+++ b/Sources/CodableKitShared/CodableKeyOptions.swift
@@ -228,12 +228,14 @@ public struct CodableKeyOptions: OptionSet, Sendable {
   ///             by falling back to the default value or `nil`.
   public static let useDefaultOnFailure = Self(rawValue: 1 << 4)
 
-  /// Decode the value as a lossy array.
+  /// Decode the value in a lossy way for collections.
   ///
-  /// This option is useful when you want to decode a JSON array as a lossy array.
-  /// The invalid items will be dropped, and the valid items will be decoded.
+  /// - For arrays and sets: invalid elements are dropped.
+  /// - For dictionaries: entries with invalid values (or keys that cannot be
+  ///   converted from JSON string keys) are dropped.
   ///
-  /// - Note: This option is only supported for array properties.
+  /// This option is useful when you want to tolerate partially-invalid data
+  /// from APIs without failing the entire decode.
   public static let lossy = Self(rawValue: 1 << 5)
 }
 

--- a/Tests/CodableKitTests/CodableMacroTests+lossy.data.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+lossy.data.swift
@@ -42,6 +42,42 @@ struct LossySafeTranscodeModel {
   var values: [Int] = [1, 2]
 }
 
+@Codable
+struct LossyDictStringIntModel {
+  @CodableKey(options: .lossy)
+  var map: [String: Int]
+}
+
+@Codable
+struct LossyDictIntDoubleModel {
+  @CodableKey(options: .lossy)
+  var map: [Int: Double]
+}
+
+@Codable
+struct LossyOptionalDictModel {
+  @CodableKey(options: .lossy)
+  var scores: [String: Int]?
+}
+
+@Codable
+struct LossyDictDefaultModel {
+  @CodableKey(options: [.lossy, .useDefaultOnFailure])
+  var map: [String: Int] = ["a": 1]
+}
+
+@Codable
+struct LossyDictTranscodeModel {
+  @CodableKey(options: [.lossy, .transcodeRawString])
+  var map: [String: Int]
+}
+
+@Codable
+struct LossyDictSafeTranscodeModel {
+  @CodableKey(options: [.lossy, .safeTranscodeRawString])
+  var map: [String: Int] = [:]
+}
+
 @Suite struct LossyRuntimeTests {
   @Test func lossyArray_dropsInvalidElements() throws {
     let json = #"{"items":[{"id":1},{"id":"oops"},{"id":3},{"bad":true},4,{"id":5}] }"#
@@ -82,5 +118,53 @@ struct LossySafeTranscodeModel {
     let data = payload.data(using: .utf8)!
     let decoded = try JSONDecoder().decode(LossySafeTranscodeModel.self, from: data)
     #expect(decoded.values == [1, 2])
+  }
+
+  @Test func lossyDict_dropsInvalidEntries() throws {
+    // Mixed types inside the object; invalid entries dropped
+    let json = #"{"map":{"a":1,"b":"oops","c":3,"d":true,"e":4}}"#
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LossyDictStringIntModel.self, from: data)
+    #expect(decoded.map == ["a": 1, "c": 3, "e": 4])
+  }
+
+  @Test func lossyDict_dropsNonConvertibleKeys_andInvalidValues() throws {
+    // Keys must be LosslessStringConvertible (Int). "two" cannot convert and is dropped.
+    // Also drops value that cannot decode as Double
+    let json = #"{"map":{"1":0.5,"two":2.5,"3":"bad","4":4}}"#
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LossyDictIntDoubleModel.self, from: data)
+    #expect(decoded.map == [1: 0.5, 4: 4.0])
+  }
+
+  @Test func lossyDict_optional_missingKey_isNil() throws {
+    let json = #"{}"#
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LossyOptionalDictModel.self, from: data)
+    #expect(decoded.scores == nil)
+  }
+
+  @Test func lossyDict_withDefault_and_useDefaultOnFailure() throws {
+    // Non-dictionary value → fallback to default due to .useDefaultOnFailure
+    let json = #"{"map": 123}"#
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LossyDictDefaultModel.self, from: data)
+    #expect(decoded.map == ["a": 1])
+  }
+
+  @Test func lossyDict_transcodeRawString_combined() throws {
+    // Dictionary encoded as a JSON string with some invalid entries
+    let embedded = #"{\"a\":1,\"b\":\"oops\",\"c\":3}"#
+    let payload = #"{"map":"\#(embedded)"}"#
+    let data = payload.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LossyDictTranscodeModel.self, from: data)
+    #expect(decoded.map == ["a": 1, "c": 3])
+  }
+
+  @Test func lossyDict_safeTranscodeRawString_withDefault() throws {
+    let payload = #"{"map": null}"#
+    let data = payload.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(LossyDictSafeTranscodeModel.self, from: data)
+    #expect(decoded.map == [:])
   }
 }

--- a/Tests/DecodableKitTests/CodableMacroTests+lossy.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+lossy.swift
@@ -227,4 +227,186 @@ import Testing
         """
     )
   }
+
+  @Test func lossyDictionary_nonOptional_noDefault() throws {
+    assertMacro(
+      """
+      @Decodable
+      public struct Model {
+        @CodableKey(options: .lossy)
+        let map: [String: Int]
+        @CodableKey(options: .lossy)
+        let other: Dictionary<String, Int>
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          let map: [String: Int]
+          let other: Dictionary<String, Int>
+        }
+
+        extension Model: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case map
+            case other
+          }
+
+          public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let mapLossyWrapper = try container.decode(LossyDictionary<String, Int>.self, forKey: .map)
+            map = mapLossyWrapper.elements
+            let otherLossyWrapper = try container.decode(LossyDictionary<String, Int>.self, forKey: .other)
+            other = otherLossyWrapper.elements
+            try didDecode(from: decoder)
+          }
+        }
+        """
+    )
+  }
+
+  @Test func lossyDictionary_optional() throws {
+    assertMacro(
+      """
+      @Decodable
+      public struct Model {
+        @CodableKey(options: .lossy)
+        let map: [String: Int]?
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          let map: [String: Int]?
+        }
+
+        extension Model: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case map
+          }
+
+          public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let mapLossyWrapper = try container.decodeIfPresent(LossyDictionary<String, Int>.self, forKey: .map) ?? nil
+            if let mapLossyUnwrapped = mapLossyWrapper {
+              map = mapLossyUnwrapped.elements
+            } else {
+              map = nil
+            }
+            try didDecode(from: decoder)
+          }
+        }
+        """
+    )
+  }
+
+  @Test func lossyDictionary_nonOptional_withDefault_and_useDefaultOnFailure() throws {
+    assertMacro(
+      """
+      @Decodable
+      public struct Model {
+        @CodableKey(options: [.lossy, .useDefaultOnFailure])
+        var map: [String: Int] = ["a": 1]
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          var map: [String: Int] = ["a": 1]
+        }
+
+        extension Model: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case map
+          }
+
+          public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let mapLossyWrapper = (try? container.decodeIfPresent(LossyDictionary<String, Int>.self, forKey: .map)) ?? nil
+            if let mapLossyUnwrapped = mapLossyWrapper {
+              map = mapLossyUnwrapped.elements
+            } else {
+              map = ["a": 1]
+            }
+            try didDecode(from: decoder)
+          }
+        }
+        """
+    )
+  }
+
+  @Test func lossyDictionary_combined_with_transcodeRawString() throws {
+    assertMacro(
+      """
+      @Decodable
+      public struct Model {
+        @CodableKey(options: [.lossy, .transcodeRawString])
+        let map: [String: Int]
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          let map: [String: Int]
+        }
+
+        extension Model: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case map
+          }
+
+          public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let __ckDecoder = JSONDecoder()
+            let mapRawString = try container.decodeIfPresent(String.self, forKey: .map) ?? ""
+            if !mapRawString.isEmpty, let mapRawData = mapRawString.data(using: .utf8) {
+              let mapLossyWrapper = try __ckDecoder.decode(LossyDictionary<String, Int>.self, from: mapRawData)
+              map = mapLossyWrapper.elements
+            } else {
+              throw DecodingError.valueNotFound(
+                String.self,
+                DecodingError.Context(
+                  codingPath: [CodingKeys.map],
+                  debugDescription: "Failed to convert raw string to data"
+                )
+              )
+            }
+            try didDecode(from: decoder)
+          }
+        }
+        """
+    )
+  }
+
+  @Test func lossyDictionary_combined_with_safeTranscodeRawString() throws {
+    assertMacro(
+      """
+      @Decodable
+      public struct Model {
+        @CodableKey(options: [.lossy, .safeTranscodeRawString])
+        var map: [String: Int] = [:]
+      }
+      """,
+      expandedSource: """
+        public struct Model {
+          var map: [String: Int] = [:]
+        }
+
+        extension Model: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case map
+          }
+
+          public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let __ckDecoder = JSONDecoder()
+            let mapRawString = (try? container.decodeIfPresent(String.self, forKey: .map)) ?? ""
+            if !mapRawString.isEmpty, let mapRawData = mapRawString.data(using: .utf8) {
+              let mapLossyWrapper = try __ckDecoder.decode(LossyDictionary<String, Int>.self, from: mapRawData)
+              map = mapLossyWrapper.elements
+            } else {
+              map = [:]
+            }
+            try didDecode(from: decoder)
+          }
+        }
+        """
+    )
+  }
 }


### PR DESCRIPTION
This pull request adds support for lossy decoding of dictionaries in the CodableKit library, allowing properties of type `Dictionary` to drop invalid entries or keys during decoding. The change is reflected across the macro system, documentation, and tests, bringing dictionary support in line with existing lossy decoding for arrays and sets. The documentation and warnings have been updated, and comprehensive tests have been added to verify the new behavior.

**Lossy decoding for collections**

* Added `LossyDictionary` type to enable lossy decoding for dictionaries, which skips entries with invalid values or keys that can't be converted from JSON string keys. (`Sources/CodableKit/LossyDictionary.swift`)
* Updated macro code generation to support `.lossy` on dictionary properties, including type detection and wrapper generation for both direct and transcoded decoding scenarios. (`Sources/CodableKitMacros/CodableProperty.swift`, `Sources/CodableKitMacros/NamespaceNode+Decode.swift`) [[1]](diffhunk://#diff-0591261f30ee950510ef2b840c34365f65c790d34a27e0a94f3e2863d975e59aR204-R213) [[2]](diffhunk://#diff-0591261f30ee950510ef2b840c34365f65c790d34a27e0a94f3e2863d975e59aR229-R246) [[3]](diffhunk://#diff-eb6244026f9dfaffac4b097e2c7f98eb05fcc8e48829bd25ca0137d59c9c560dL72-R78) [[4]](diffhunk://#diff-eb6244026f9dfaffac4b097e2c7f98eb05fcc8e48829bd25ca0137d59c9c560dL100-R131) [[5]](diffhunk://#diff-eb6244026f9dfaffac4b097e2c7f98eb05fcc8e48829bd25ca0137d59c9c560dL264-R313)
* Modified option set and warnings to clarify `.lossy` now supports arrays, sets, and dictionaries. (`Sources/CodableKitShared/CodableKeyOptions.swift`, `Sources/CodableKitMacros/CodeGenCore.swift`) [[1]](diffhunk://#diff-21bfcfa1db3c7b3a9eefe22cd5efba8a5b3202c059153212faf390841f2a1752L231-R238) [[2]](diffhunk://#diff-ff70c8cdcab694fe73d53c4ca01b432d14d33955ab3ec54eb7ff2b24b1e465cfL363-R367)

**Documentation updates**

* Expanded documentation to describe lossy dictionary decoding, including usage notes, examples, and updated option descriptions. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R210) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L221-R260)

**Test coverage**

* Added new test models and cases to verify lossy dictionary decoding, including combinations with default values, optionals, and transcoding from JSON strings. (`Tests/CodableKitTests/CodableMacroTests+lossy.data.swift`) [[1]](diffhunk://#diff-aa7a748d6f1c3f99a27c7fa133859da7a8a0541e9a8600540f071b468c7d41ecR45-R80) [[2]](diffhunk://#diff-aa7a748d6f1c3f99a27c7fa133859da7a8a0541e9a8600540f071b468c7d41ecR122-R169)

**Roadmap updates**

* Updated the project roadmap to mark lossy dictionary decoding as complete and clarified milestone status. (`ROADMAP.md`) [[1]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L13-R13) [[2]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L55-R55)