### PR TITLE
Remove CodableKitShared and refactor option types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,16 +25,9 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"603.0.0")
   ],
   targets: [
-    .target(
-      name: "CodableKitShared",
-      dependencies: [
-        .product(name: "SwiftSyntax", package: "swift-syntax")
-      ]
-    ),
     .macro(
       name: "CodableKitMacros",
       dependencies: [
-        "CodableKitShared",
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
@@ -43,7 +36,6 @@ let package = Package(
     .target(
       name: "CodableKit",
       dependencies: [
-        "CodableKitShared",
         "CodableKitMacros",
       ]
     ),
@@ -51,7 +43,6 @@ let package = Package(
       name: "CodableKitTests",
       dependencies: [
         "CodableKit",
-        "CodableKitShared",
         "CodableKitMacros",
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
@@ -61,7 +52,6 @@ let package = Package(
       name: "DecodableKitTests",
       dependencies: [
         "CodableKit",
-        "CodableKitShared",
         "CodableKitMacros",
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
@@ -71,7 +61,6 @@ let package = Package(
       name: "EncodableKitTests",
       dependencies: [
         "CodableKit",
-        "CodableKitShared",
         "CodableKitMacros",
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
@@ -81,7 +70,6 @@ let package = Package(
       name: "TransformerTests",
       dependencies: [
         "CodableKit",
-        "CodableKitShared",
         "CodableKitMacros",
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),

--- a/Sources/CodableKit/CodableKeyOptions.swift
+++ b/Sources/CodableKit/CodableKeyOptions.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 WendellXY. All rights reserved.
 //
 
-import SwiftSyntax
-
 public struct CodableKeyOptions: OptionSet, Sendable {
   public let rawValue: Int32
 
@@ -237,48 +235,4 @@ public struct CodableKeyOptions: OptionSet, Sendable {
   /// This option is useful when you want to tolerate partially-invalid data
   /// from APIs without failing the entire decode.
   public static let lossy = Self(rawValue: 1 << 5)
-}
-
-// MARK: It will be nice to use a macro to generate this code below.
-extension CodableKeyOptions {
-  package init(from expr: MemberAccessExprSyntax) {
-    self =
-      switch expr.declName.baseName.text {
-      case "ignored": .ignored
-      case "explicitNil": .explicitNil
-      case "generateCustomKey": .generateCustomKey
-      case "transcodeRawString": .transcodeRawString
-      case "useDefaultOnFailure": .useDefaultOnFailure
-      case "safeTranscodeRawString": .safeTranscodeRawString
-      case "lossy": .lossy
-      default: .default
-      }
-  }
-}
-
-extension CodableKeyOptions {
-  /// Parse the options from 1a `LabelExprSyntax`. It support parse a single element like `.default`,
-  /// or multiple elements like `[.ignored, .explicitNil]`
-  package static func parse(from labeledExpr: LabeledExprSyntax) -> Self {
-    if let memberAccessExpr = labeledExpr.expression.as(MemberAccessExprSyntax.self) {
-      Self.init(from: memberAccessExpr)
-    } else if let arrayExpr = labeledExpr.expression.as(ArrayExprSyntax.self) {
-      arrayExpr.elements
-        .compactMap { $0.expression.as(MemberAccessExprSyntax.self) }
-        .map { Self.init(from: $0) }
-        .reduce(.default) { $0.union($1) }
-    } else {
-      .default
-    }
-  }
-}
-
-extension LabeledExprSyntax {
-  /// Parse the options from a `LabelExprSyntax`. It support parse a single element like .default,
-  /// or multiple elements like [.ignored, .explicitNil].
-  ///
-  /// This is a convenience method to use for chaining.
-  package func parseOptions() -> CodableKeyOptions {
-    CodableKeyOptions.parse(from: self)
-  }
 }

--- a/Sources/CodableKit/CodableKit.swift
+++ b/Sources/CodableKit/CodableKit.swift
@@ -5,11 +5,6 @@
 //  Created by Wendell on 3/30/24.
 //
 
-// We should not import the plugin here, otherwise, a compile error will occur. Reference:
-// https://forums.swift.org/t/xcode-15-beta-no-such-module-error-with-swiftpm-and-macro/65486/12
-// import CodableKitMacros
-@_exported import CodableKitShared
-
 /// A macro that generates complete `Codable` conformance for structs and classes.
 ///
 /// This macro automatically generates all the boilerplate code needed for `Codable` conformance,

--- a/Sources/CodableKit/CodableOptions.swift
+++ b/Sources/CodableKit/CodableOptions.swift
@@ -1,0 +1,26 @@
+//
+//  CodableOptions.swift
+//  CodableKit
+//
+//  Created by Wendell Wang on 2025/1/13.
+//
+
+/// Options that customize the behavior of the `@Codable` macro expansion.
+public struct CodableOptions: OptionSet, Sendable {
+  public let rawValue: Int32
+
+  public init(rawValue: Int32) {
+    self.rawValue = rawValue
+  }
+
+  /// The default options, which perform standard Codable expansion with super encode/decode calls.
+  public static let `default`: Self = []
+
+  /// Skips generating super encode/decode calls in the expanded code.
+  ///
+  /// Use this option when the superclass doesn't conform to `Codable`.
+  /// When enabled:
+  /// - Replaces `super.init(from: decoder)` with `super.init()`
+  /// - Removes `super.encode(to: encoder)` call entirely
+  public static let skipSuperCoding = Self(rawValue: 1 << 0)
+}

--- a/Sources/CodableKitMacros/CodableKeyOptions.swift
+++ b/Sources/CodableKitMacros/CodableKeyOptions.swift
@@ -5,19 +5,80 @@
 //  Created by Wendell on 4/3/24.
 //
 
-import CodableKitShared
+import SwiftSyntax
+
+struct CodableKeyOptions: OptionSet, Sendable {
+  let rawValue: Int32
+
+  init(rawValue: Int32) {
+    self.rawValue = rawValue
+  }
+
+  static let `default`: Self = []
+  static let safeTranscodeRawString: Self = [.transcodeRawString, .useDefaultOnFailure]
+  static let ignored = Self(rawValue: 1 << 0)
+  static let explicitNil = Self(rawValue: 1 << 1)
+  static let generateCustomKey = Self(rawValue: 1 << 2)
+  static let transcodeRawString = Self(rawValue: 1 << 3)
+  static let useDefaultOnFailure = Self(rawValue: 1 << 4)
+  static let lossy = Self(rawValue: 1 << 5)
+}
+
+extension CodableKeyOptions {
+  package init(from expr: MemberAccessExprSyntax) {
+    self =
+      switch expr.declName.baseName.text {
+      case "ignored": .ignored
+      case "explicitNil": .explicitNil
+      case "generateCustomKey": .generateCustomKey
+      case "transcodeRawString": .transcodeRawString
+      case "useDefaultOnFailure": .useDefaultOnFailure
+      case "safeTranscodeRawString": .safeTranscodeRawString
+      case "lossy": .lossy
+      default: .default
+      }
+  }
+}
+
+extension CodableKeyOptions {
+  /// Parse the options from 1a `LabelExprSyntax`. It support parse a single element like `.default`,
+  /// or multiple elements like `[.ignored, .explicitNil]`
+  package static func parse(from labeledExpr: LabeledExprSyntax) -> Self {
+    if let memberAccessExpr = labeledExpr.expression.as(MemberAccessExprSyntax.self) {
+      Self.init(from: memberAccessExpr)
+    } else if let arrayExpr = labeledExpr.expression.as(ArrayExprSyntax.self) {
+      arrayExpr.elements
+        .compactMap { $0.expression.as(MemberAccessExprSyntax.self) }
+        .map { Self.init(from: $0) }
+        .reduce(.default) { $0.union($1) }
+    } else {
+      .default
+    }
+  }
+}
+
+extension LabeledExprSyntax {
+  /// Parse the options from a `LabelExprSyntax`. It support parse a single element like .default,
+  /// or multiple elements like [.ignored, .explicitNil].
+  ///
+  /// This is a convenience method to use for chaining.
+  func parseOptions() -> CodableKeyOptions {
+    CodableKeyOptions.parse(from: self)
+  }
+}
+
 
 extension CodableKeyMacro {
   /// Options for customizing the behavior of a `CodableKey`.
-  package typealias Options = CodableKeyOptions
+  typealias Options = CodableKeyOptions
 }
 
 extension DecodableKeyMacro {
   /// Options for customizing the behavior of a `DecodeKey`.
-  package typealias Options = CodableKeyOptions
+  typealias Options = CodableKeyOptions
 }
 
 extension EncodableKeyMacro {
   /// Options for customizing the behavior of an `EncodeKey`.
-  package typealias Options = CodableKeyOptions
+  typealias Options = CodableKeyOptions
 }

--- a/Sources/CodableKitMacros/CodableKeyOptions.swift
+++ b/Sources/CodableKitMacros/CodableKeyOptions.swift
@@ -25,7 +25,7 @@ struct CodableKeyOptions: OptionSet, Sendable {
 }
 
 extension CodableKeyOptions {
-  package init(from expr: MemberAccessExprSyntax) {
+  init(from expr: MemberAccessExprSyntax) {
     self =
       switch expr.declName.baseName.text {
       case "ignored": .ignored
@@ -43,7 +43,7 @@ extension CodableKeyOptions {
 extension CodableKeyOptions {
   /// Parse the options from 1a `LabelExprSyntax`. It support parse a single element like `.default`,
   /// or multiple elements like `[.ignored, .explicitNil]`
-  package static func parse(from labeledExpr: LabeledExprSyntax) -> Self {
+  static func parse(from labeledExpr: LabeledExprSyntax) -> Self {
     if let memberAccessExpr = labeledExpr.expression.as(MemberAccessExprSyntax.self) {
       Self.init(from: memberAccessExpr)
     } else if let arrayExpr = labeledExpr.expression.as(ArrayExprSyntax.self) {

--- a/Sources/CodableKitMacros/CodableMacro.swift
+++ b/Sources/CodableKitMacros/CodableMacro.swift
@@ -5,7 +5,6 @@
 //  Created by Wendell on 3/30/24.
 //
 
-import CodableKitShared
 import Foundation
 import SwiftDiagnostics
 import SwiftSyntax

--- a/Sources/CodableKitMacros/CodableOptions.swift
+++ b/Sources/CodableKitMacros/CodableOptions.swift
@@ -2,33 +2,24 @@
 //  CodableOptions.swift
 //  CodableKit
 //
-//  Created by Wendell Wang on 2025/1/13.
+//  Created by Wendell Wang on 2025/10/2.
 //
 
 import SwiftSyntax
 
-/// Options that customize the behavior of the `@Codable` macro expansion.
-public struct CodableOptions: OptionSet, Sendable {
-  public let rawValue: Int32
+struct CodableOptions: OptionSet, Sendable {
+  let rawValue: Int32
 
-  public init(rawValue: Int32) {
+  init(rawValue: Int32) {
     self.rawValue = rawValue
   }
 
-  /// The default options, which perform standard Codable expansion with super encode/decode calls.
-  public static let `default`: Self = []
-
-  /// Skips generating super encode/decode calls in the expanded code.
-  ///
-  /// Use this option when the superclass doesn't conform to `Codable`.
-  /// When enabled:
-  /// - Replaces `super.init(from: decoder)` with `super.init()`
-  /// - Removes `super.encode(to: encoder)` call entirely
-  public static let skipSuperCoding = Self(rawValue: 1 << 0)
+  static let `default`: Self = []
+  static let skipSuperCoding = Self(rawValue: 1 << 0)
 }
 
 extension CodableOptions {
-  package init(from expr: MemberAccessExprSyntax) {
+  init(from expr: MemberAccessExprSyntax) {
     let variableName = expr.declName.baseName.text
     switch variableName {
     case "skipSuperCoding":
@@ -42,7 +33,7 @@ extension CodableOptions {
 extension CodableOptions {
   /// Parse the options from 1a `LabelExprSyntax`. It support parse a single element like `.default`,
   /// or multiple elements like `[.ignored, .explicitNil]`
-  package static func parse(from labeledExpr: LabeledExprSyntax) -> Self {
+  static func parse(from labeledExpr: LabeledExprSyntax) -> Self {
     if let memberAccessExpr = labeledExpr.expression.as(MemberAccessExprSyntax.self) {
       Self.init(from: memberAccessExpr)
     } else if let arrayExpr = labeledExpr.expression.as(ArrayExprSyntax.self) {
@@ -61,7 +52,7 @@ extension LabeledExprSyntax {
   /// or multiple elements like [.ignored, .explicitNil].
   ///
   /// This is a convenience method to use for chaining.
-  package func parseCodableOptions() -> CodableOptions {
+  func parseCodableOptions() -> CodableOptions {
     CodableOptions.parse(from: self)
   }
 }

--- a/Sources/CodableKitMacros/CodeGenCore.swift
+++ b/Sources/CodableKitMacros/CodeGenCore.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2024 WendellXY. All rights reserved.
 //
 
-import CodableKitShared
 import Foundation
 import SwiftDiagnostics
 import SwiftSyntax


### PR DESCRIPTION
Eliminates the CodableKitShared target and migrates CodableKeyOptions and CodableOptions into CodableKit and CodableKitMacros, respectively. Updates all references and implementations to use the new locations, and removes unnecessary imports. This simplifies the package structure and clarifies the separation between runtime and macro-related code.