### PR TITLE
Dynamic Codable Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Add to your Package.swift dependencies:
 | Use default on failure         | `@CodableKey(options: .useDefaultOnFailure)`        | Fallback to default/nil on decoding error                    |
 | Generate custom key property   | `@CodableKey("id", options: .generateCustomKey)`    | Adds computed property for custom key                        |
 | Explicit nil encoding          | `@CodableKey(options: .explicitNil)`                | Encode nil as `null`, not omitted                            |
-| Coding lifecycle hooks         | `func didDecode(from:)`, `func willEncode(to:)`     | Run logic during encoding/decoding                           |
+| Coding lifecycle hooks         | `static willDecode(from:)`, `func didDecode(from:)`, `func willEncode(to:)`, `func didEncode(to:)` | Run logic during encoding/decoding; annotate with `@CodableHook` for explicit control |
 | Transformers (advanced)        | `@CodableKey(transformer: MyTransformer())`         | Apply custom/built‑in transforms, compose with bidirectional |
 
 ## Usage Guides and Examples
@@ -216,6 +216,10 @@ struct User {
   var name: String
   var age: Int
 
+  // Runs before any properties are decoded (static-only)
+  @CodableHook(.willDecode)
+  static func pre(from decoder: any Decoder) throws { /* prepare decoder/userInfo */ }
+
   mutating func didDecode(from decoder: any Decoder) throws {
     id = "\(name)-\(age)" // recompute derived values
   }
@@ -225,29 +229,29 @@ struct User {
 }
 ```
 
-### Why There’s No `willDecode`
+### Annotated Hooks (Recommended)
 
-A pre‑decode instance hook (like `willDecode`) cannot be implemented safely in Swift because `self` is not fully
-initialized at the point where such a hook would need to run:
+- Use `@CodableHook(<stage>)` to explicitly mark lifecycle methods:
+  - `.willDecode`: static/class method, signature `from decoder: any Decoder`, runs before property decoding.
+  - `.didDecode`: instance method, signature `from decoder: any Decoder`, runs after decoding completes.
+  - `.willEncode` / `.didEncode`: instance methods, signature `to encoder: any Encoder`, run before/after encoding.
+- Multiple hooks per stage are supported and called in declaration order.
+- You can pick any method names when annotated; the macro invokes the annotated methods.
+- If no annotations are present, conventional names are still detected for compatibility.
 
-- During `init(from:)`, stored properties must be initialized before you can use `self` (structs) and before or after
-  `super.init` depending on class initialization rules.
-- A `willDecode` hook would need to execute before properties are assigned from the decoder, which is precisely when
-  `self` cannot be used. Emitting an instance call there would cause “self used before initialization” issues.
+### Why There’s No Instance `willDecode`
 
-CodableKit therefore supports:
+An instance `willDecode` is unsafe in Swift because `self` isn’t fully initialized before property decoding begins, so
+calling an instance method there would violate initialization rules. Instead, CodableKit provides:
 
-- `didDecode(from:)`: Runs after decoding completes, when `self` is safe to use.
-- `willEncode(to:)`/`didEncode(to:)`: Run before/after encoding on a fully‑initialized instance.
+- `@CodableHook(.willDecode)` static/class hook that runs before decode.
+- `didDecode(from:)` instance hook that runs after decode completes.
+- `willEncode(to:)` / `didEncode(to:)` instance hooks around encoding.
 
-Recommended patterns instead of `willDecode`:
-
-- Use property default values to establish baseline state prior to decoding.
-- Perform normalization or derive fields in `didDecode(from:)` after the model is populated.
-- If you need to adjust decoding behavior globally, do so at the call site (e.g., prepare `JSONDecoder`, `userInfo`, or
-  preprocess raw data) before invoking `decode`.
-
-Note: Hooks are generated only when the corresponding methods are implemented on your type; there is no protocol requirement.
+Tips:
+- Use property defaults for baseline state before decoding.
+- Put normalization/derivations in `didDecode(from:)`.
+- Preprocess or configure the decoder (e.g., `userInfo`) before calling `decode` when needed.
 
 ## Options Reference
 

--- a/Sources/CodableKit/CodableHook.swift
+++ b/Sources/CodableKit/CodableHook.swift
@@ -1,0 +1,54 @@
+//
+//  CodableHook.swift
+//  CodableKit
+//
+//  Created by Wendell Wang on 2025/10/2.
+//
+
+/// Lifecycle stages at which `@CodableHook`-annotated methods are invoked.
+///
+/// Use these values with `@CodableHook(_:)` on methods to opt into
+/// invocation during macro-generated `init(from:)` and `encode(to:)`.
+///
+/// Call order:
+/// - Decoding: all `.willDecode` hooks → property decoding → all `.didDecode` hooks
+/// - Encoding: all `.willEncode` hooks → property encoding → all `.didEncode` hooks
+///
+/// Multiple hooks per stage are supported and are called in declaration order.
+public enum HookStage: String, Sendable {
+  /// Runs before any property decoding occurs inside `init(from:)`.
+  /// - Usage: annotate a static/class method with `@CodableHook(.willDecode)`.
+  ///   The method should accept `from decoder: any Decoder` and can throw.
+  /// - Important: Must be a `static` or `class` method; instance `willDecode` is not supported.
+  case willDecode
+
+  /// Runs immediately before property encoding in `encode(to:)`.
+  /// - Usage: annotate an instance method with `@CodableHook(.willEncode)`.
+  ///   The method should accept `to encoder: any Encoder` and can throw.
+  /// - Note: Should be nonmutating.
+  case willEncode
+
+  /// Runs after property encoding completes in `encode(to:)`.
+  /// - Usage: annotate an instance method with `@CodableHook(.didEncode)`.
+  ///   The method should accept `to encoder: any Encoder` and can throw.
+  /// - Note: Should be nonmutating.
+  case didEncode
+
+  /// Runs after all properties have been decoded in `init(from:)`.
+  /// - Usage: annotate an instance method with `@CodableHook(.didDecode)`.
+  ///   The method should accept `from decoder: any Decoder` and can throw.
+  /// - Note: May be `mutating` for structs.
+  case didDecode
+}
+
+/// Marks a method to be invoked by the container macro at a particular coding stage.
+///
+/// Usage:
+/// - `@CodableHook(.willDecode)` on static methods taking `(from decoder: any Decoder)`
+/// - `@CodableHook(.didDecode)` on methods taking `(from decoder: any Decoder)`
+/// - `@CodableHook(.willEncode)` or `@CodableHook(.didEncode)` on methods taking `(to encoder: any Encoder)`
+///
+/// Note:
+/// - Hooks should be `throws` and nonmutating for encode stages. For structs, `.didDecode` may be `mutating`.
+@attached(peer)
+public macro CodableHook(_ stage: HookStage) = #externalMacro(module: "CodableKitMacros", type: "CodingHookMacro")

--- a/Sources/CodableKit/CodableKit.swift
+++ b/Sources/CodableKit/CodableKit.swift
@@ -27,7 +27,7 @@
 /// }
 /// ```
 ///
-/// This generates:
+/// This generates (simplified):
 ///
 /// ```swift
 /// extension User: Codable {
@@ -40,16 +40,13 @@
 ///         id = try container.decode(Int.self, forKey: .id)
 ///         name = try container.decode(String.self, forKey: .name)
 ///         age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 25
-///         try didDecode(from: decoder)
 ///     }
 ///
 ///     func encode(to encoder: Encoder) throws {
-///         try willEncode(to: encoder)
 ///         var container = encoder.container(keyedBy: CodingKeys.self)
 ///         try container.encode(id, forKey: .id)
 ///         try container.encode(name, forKey: .name)
 ///         try container.encode(age, forKey: .age)
-///         try didEncode(to: encoder)
 ///     }
 /// }
 /// ```
@@ -138,7 +135,6 @@
 ///
 /// The macro automatically adds conformance to:
 /// - `Codable` (combines `Encodable` and `Decodable`)
-/// - `CodableHooks` (for lifecycle hook support)
 ///
 /// ## Compile-Time Safety
 ///
@@ -150,7 +146,7 @@
 ///
 /// - Parameters:
 ///   - options: Configuration options for the macro behavior. Defaults to `.default`.
-@attached(extension, conformances: Codable, CodableHooks, names: named(CodingKeys), named(init(from:)), arbitrary)
+@attached(extension, conformances: Codable, names: named(CodingKeys), named(init(from:)), arbitrary)
 @attached(member, conformances: Codable, names: named(init(from:)), named(encode(to:)), arbitrary)
 public macro Codable(
   options: CodableOptions = .default
@@ -178,7 +174,7 @@ public macro Codable(
 /// }
 /// ```
 ///
-/// This generates:
+/// This generates (simplified):
 ///
 /// ```swift
 /// extension User: Decodable {
@@ -191,7 +187,6 @@ public macro Codable(
 ///         id = try container.decode(Int.self, forKey: .id)
 ///         name = try container.decode(String.self, forKey: .name)
 ///         age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 25
-///         try didDecode(from: decoder)
 ///     }
 /// }
 /// ```
@@ -272,7 +267,6 @@ public macro Codable(
 ///
 /// The macro automatically adds conformance to:
 /// - `Decodable`
-/// - `DecodingHooks` (for lifecycle hook support)
 ///
 /// ## When to Use
 ///
@@ -284,7 +278,7 @@ public macro Codable(
 ///
 /// - Parameters:
 ///   - options: Configuration options for the macro behavior. Defaults to `.default`.
-@attached(extension, conformances: Decodable, DecodingHooks, names: named(CodingKeys), named(init(from:)), arbitrary)
+@attached(extension, conformances: Decodable, names: named(CodingKeys), named(init(from:)), arbitrary)
 @attached(member, conformances: Decodable, names: named(init(from:)), arbitrary)
 public macro Decodable(
   options: CodableOptions = .default
@@ -312,7 +306,7 @@ public macro Decodable(
 /// }
 /// ```
 ///
-/// This generates:
+/// This generates (simplified):
 ///
 /// ```swift
 /// extension User: Encodable {
@@ -321,12 +315,10 @@ public macro Decodable(
 ///     }
 ///
 ///     func encode(to encoder: Encoder) throws {
-///         try willEncode(to: encoder)
 ///         var container = encoder.container(keyedBy: CodingKeys.self)
 ///         try container.encode(id, forKey: .id)
 ///         try container.encode(name, forKey: .name)
 ///         try container.encode(age, forKey: .age)
-///         try didEncode(to: encoder)
 ///     }
 /// }
 /// ```
@@ -410,7 +402,6 @@ public macro Decodable(
 ///
 /// The macro automatically adds conformance to:
 /// - `Encodable`
-/// - `EncodingHooks` (for lifecycle hook support)
 ///
 /// ## When to Use
 ///
@@ -422,7 +413,7 @@ public macro Decodable(
 ///
 /// - Parameters:
 ///   - options: Configuration options for the macro behavior. Defaults to `.default`.
-@attached(extension, conformances: Encodable, EncodingHooks, names: named(CodingKeys), arbitrary)
+@attached(extension, conformances: Encodable, names: named(CodingKeys), arbitrary)
 @attached(member, conformances: Encodable, names: named(encode(to:)), arbitrary)
 public macro Encodable(
   options: CodableOptions = .default

--- a/Sources/CodableKitMacros/CodableMacro.swift
+++ b/Sources/CodableKitMacros/CodableMacro.swift
@@ -241,7 +241,14 @@ extension CodableMacro {
       )
     ) {
       // Call static willDecode hooks before any property decoding
-      for name in hooks.willDecode { "try Self.\(raw: name)(from: decoder)" }
+      for hook in hooks.willDecode {
+        switch hook.kind {
+        case .decoder:
+          "try Self.\(raw: hook.name)(from: decoder)"
+        case .encoder, .none:
+          "try Self.\(raw: hook.name)()"
+        }
+      }
 
       for containerDecl in tree.decodeBlockItem {
         containerDecl
@@ -255,7 +262,14 @@ extension CodableMacro {
         }
       }
 
-      for name in hooks.didDecode { "try \(raw: name)(from: decoder)" }
+      for hook in hooks.didDecode {
+        switch hook.kind {
+        case .decoder:
+          "try \(raw: hook.name)(from: decoder)"
+        case .encoder, .none:
+          "try \(raw: hook.name)()"
+        }
+      }
     }
   }
 
@@ -279,7 +293,14 @@ extension CodableMacro {
         effectSpecifiers: .init(throwsClause: .init(throwsSpecifier: .keyword(.throws)))
       )
     ) {
-      for name in hooks.willEncode { "try \(raw: name)(to: encoder)" }
+      for hook in hooks.willEncode {
+        switch hook.kind {
+        case .encoder:
+          "try \(raw: hook.name)(to: encoder)"
+        case .decoder, .none:
+          "try \(raw: hook.name)()"
+        }
+      }
 
       for containerDecl in tree.encodeBlockItem {
         containerDecl
@@ -289,7 +310,14 @@ extension CodableMacro {
         "try super.encode(to: encoder)"
       }
 
-      for name in hooks.didEncode { "try \(raw: name)(to: encoder)" }
+      for hook in hooks.didEncode {
+        switch hook.kind {
+        case .encoder:
+          "try \(raw: hook.name)(to: encoder)"
+        case .decoder, .none:
+          "try \(raw: hook.name)()"
+        }
+      }
     }
   }
 }

--- a/Sources/CodableKitMacros/CodableMacro.swift
+++ b/Sources/CodableKitMacros/CodableMacro.swift
@@ -240,6 +240,9 @@ extension CodableMacro {
         effectSpecifiers: .init(throwsClause: .init(throwsSpecifier: .keyword(.throws)))
       )
     ) {
+      // Call static willDecode hooks before any property decoding
+      for name in hooks.willDecode { "try Self.\(raw: name)(from: decoder)" }
+
       for containerDecl in tree.decodeBlockItem {
         containerDecl
       }
@@ -252,9 +255,7 @@ extension CodableMacro {
         }
       }
 
-      if hooks.didDecode {
-        "try didDecode(from: decoder)"
-      }
+      for name in hooks.didDecode { "try \(raw: name)(from: decoder)" }
     }
   }
 
@@ -278,9 +279,7 @@ extension CodableMacro {
         effectSpecifiers: .init(throwsClause: .init(throwsSpecifier: .keyword(.throws)))
       )
     ) {
-      if hooks.willEncode {
-        "try willEncode(to: encoder)"
-      }
+      for name in hooks.willEncode { "try \(raw: name)(to: encoder)" }
 
       for containerDecl in tree.encodeBlockItem {
         containerDecl
@@ -290,9 +289,7 @@ extension CodableMacro {
         "try super.encode(to: encoder)"
       }
 
-      if hooks.didEncode {
-        "try didEncode(to: encoder)"
-      }
+      for name in hooks.didEncode { "try \(raw: name)(to: encoder)" }
     }
   }
 }

--- a/Sources/CodableKitMacros/CodingHookMacro.swift
+++ b/Sources/CodableKitMacros/CodingHookMacro.swift
@@ -1,0 +1,101 @@
+//
+//  CodableHookMacro.swift
+//  CodableKit
+//
+//  Created by Wendell Wang on 2025/10/2.
+//
+
+import Foundation
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct CodingHookMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    // Validate: must attach to a function
+    guard let fn = FunctionDeclSyntax(declaration) else {
+      let diag = Diagnostic(
+        node: node,
+        message: SimpleDiagnosticMessage(
+          message: "@CodableHook can only be attached to functions",
+          severity: .error
+        )
+      )
+      context.diagnose(diag)
+      return []
+    }
+
+    // Validate the stage argument exists
+    if node.arguments?.as(LabeledExprListSyntax.self)?.first == nil {
+      let diag = Diagnostic(
+        node: node,
+        message: SimpleDiagnosticMessage(
+          message: "@CodableHook requires a stage argument (e.g., .didDecode)",
+          severity: .error
+        )
+      )
+      context.diagnose(diag)
+      return []
+    }
+
+    // Soft validation of signature based on stage token presence
+    if let arg = node.arguments?.as(LabeledExprListSyntax.self)?.first?.expression {
+      let stageText = arg.description
+      let params = fn.signature.parameterClause.parameters
+      let isStatic = fn.modifiers.contains(where: { $0.name.text == "static" || $0.name.text == "class" })
+      if stageText.contains("didDecode") {
+        // Expect first parameter type mentions Decoder
+        if let first = params.first, !first.type.description.contains("Decoder") {
+          let diag = Diagnostic(
+            node: node,
+            message: SimpleDiagnosticMessage(
+              message: "didDecode hooks should take a Decoder parameter",
+              severity: .warning
+            )
+          )
+          context.diagnose(diag)
+        }
+      } else if stageText.contains("willEncode") || stageText.contains("didEncode") {
+        if let first = params.first, !first.type.description.contains("Encoder") {
+          let diag = Diagnostic(
+            node: node,
+            message: SimpleDiagnosticMessage(
+              message: "encode hooks should take an Encoder parameter",
+              severity: .warning
+            )
+          )
+          context.diagnose(diag)
+        }
+      } else if stageText.contains("willDecode") {
+        if !isStatic {
+          let diag = Diagnostic(
+            node: node,
+            message: SimpleDiagnosticMessage(
+              message: "willDecode hooks must be static or class methods",
+              severity: .warning
+            )
+          )
+          context.diagnose(diag)
+        }
+        if let first = params.first, !first.type.description.contains("Decoder") {
+          let diag = Diagnostic(
+            node: node,
+            message: SimpleDiagnosticMessage(
+              message: "willDecode hooks should take a Decoder parameter",
+              severity: .warning
+            )
+          )
+          context.diagnose(diag)
+        }
+      }
+    }
+
+    // No peer declarations needed; this attribute is a marker used by container macros.
+    return []
+  }
+}

--- a/Sources/CodableKitMacros/CodingHookMacro.swift
+++ b/Sources/CodableKitMacros/CodingHookMacro.swift
@@ -49,7 +49,7 @@ public struct CodingHookMacro: PeerMacro {
       let params = fn.signature.parameterClause.parameters
       let isStatic = fn.modifiers.contains(where: { $0.name.text == "static" || $0.name.text == "class" })
       if stageText.contains("didDecode") {
-        // Expect first parameter type mentions Decoder
+        // If parameter exists, prefer it to mention Decoder. If not, allow zero-parameter hooks.
         if let first = params.first, !first.type.description.contains("Decoder") {
           let diag = Diagnostic(
             node: node,

--- a/Tests/CodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -35,17 +35,14 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -84,17 +81,14 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -134,17 +128,14 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -183,17 +174,14 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -235,17 +223,14 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -288,18 +273,15 @@ import Testing
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -344,17 +326,14 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -403,17 +382,14 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -476,11 +452,9 @@ import Testing
               )
             }
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -499,7 +473,6 @@ import Testing
               )
             }
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -563,11 +536,9 @@ import Testing
               )
             }
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -586,7 +557,6 @@ import Testing
               )
             }
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -652,11 +622,9 @@ import Testing
               room = Room(id: UUID(), name: "Hello")
             }
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -675,7 +643,6 @@ import Testing
               )
             }
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -739,11 +706,9 @@ import Testing
               )
             }
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -762,7 +727,6 @@ import Testing
               )
             }
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -828,11 +792,9 @@ import Testing
               room = Room(id: UUID(), name: "Hello")
             }
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -851,7 +813,6 @@ import Testing
               )
             }
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -905,18 +866,15 @@ import Testing
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -956,16 +914,13 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             super.init()
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/CodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class.swift
@@ -33,16 +33,13 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -79,16 +76,13 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -127,16 +121,13 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -174,16 +165,13 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -224,16 +212,13 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -275,17 +260,14 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
-            try didEncode(to: encoder)
           }
         }
 
@@ -329,16 +311,13 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -386,16 +365,13 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -457,11 +433,9 @@ import Testing
                 )
               )
             }
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -479,7 +453,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -536,11 +509,9 @@ import Testing
             } else {
               room = Room(id: .init(), name: "")
             }
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -558,7 +529,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -615,11 +585,9 @@ import Testing
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -637,7 +605,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -694,11 +661,9 @@ import Testing
             } else {
               room = nil
             }
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -718,7 +683,6 @@ import Testing
                 )
               }
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -775,11 +739,9 @@ import Testing
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -797,7 +759,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -850,17 +811,14 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
-            try didEncode(to: encoder)
           }
         }
 
@@ -899,16 +857,13 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/CodableKitTests/CodableMacroTests+class_hooks.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class_hooks.swift
@@ -1,0 +1,161 @@
+//
+//  CodableMacroTests+class_hooks.swift
+//  CodableKit
+//
+//  Created by AI on 2025/10/02.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import Testing
+
+@Suite struct CodableHooksExpansionTestsForClass {
+  @Test func combinedAnnotatedHooksRunInOrder() throws {
+    assertMacro(
+      """
+      @Codable
+      public class User {
+        let id: UUID
+        let name: String
+
+        @CodableHook(.willDecode)
+        class func preA() throws {}
+        @CodableHook(.willDecode)
+        static func preB(from decoder: any Decoder) throws {}
+
+        @CodableHook(.didDecode)
+        func postA() throws {}
+        @CodableHook(.didDecode)
+        func postB(from decoder: any Decoder) throws {}
+
+        @CodableHook(.willEncode)
+        func start() throws {}
+        @CodableHook(.willEncode)
+        func ready(to encoder: any Encoder) throws {}
+
+        @CodableHook(.didEncode)
+        func finish() throws {}
+        @CodableHook(.didEncode)
+        func end(to encoder: any Encoder) throws {}
+      }
+      """,
+      expandedSource: """
+        public class User {
+          let id: UUID
+          let name: String
+
+          @CodableHook(.willDecode)
+          class func preA() throws {}
+          @CodableHook(.willDecode)
+          static func preB(from decoder: any Decoder) throws {}
+
+          @CodableHook(.didDecode)
+          func postA() throws {}
+          @CodableHook(.didDecode)
+          func postB(from decoder: any Decoder) throws {}
+
+          @CodableHook(.willEncode)
+          func start() throws {}
+          @CodableHook(.willEncode)
+          func ready(to encoder: any Encoder) throws {}
+
+          @CodableHook(.didEncode)
+          func finish() throws {}
+          @CodableHook(.didEncode)
+          func end(to encoder: any Encoder) throws {}
+
+          public required init(from decoder: any Decoder) throws {
+            try Self.preA()
+            try Self.preB(from: decoder)
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            try postA()
+            try postB(from: decoder)
+          }
+
+          public func encode(to encoder: any Encoder) throws {
+            try start()
+            try ready(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try finish()
+            try end(to: encoder)
+          }
+        }
+
+        extension User: Codable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+          }
+        }
+        """
+    )
+  }
+
+  @Test func annotatedOverridesConventionalForClass() throws {
+    assertMacro(
+      """
+      @Codable
+      public class User {
+        let id: UUID
+        let name: String
+
+        func willEncode() throws {}
+        func didEncode() throws {}
+        func didDecode() throws {}
+
+        @CodableHook(.willEncode)
+        func start() throws {}
+        @CodableHook(.didEncode)
+        func finish() throws {}
+        @CodableHook(.didDecode)
+        func post() throws {}
+      }
+      """,
+      expandedSource: """
+        public class User {
+          let id: UUID
+          let name: String
+
+          func willEncode() throws {}
+          func didEncode() throws {}
+          func didDecode() throws {}
+
+          @CodableHook(.willEncode)
+          func start() throws {}
+          @CodableHook(.didEncode)
+          func finish() throws {}
+          @CodableHook(.didDecode)
+          func post() throws {}
+
+          public required init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            try post()
+          }
+
+          public func encode(to encoder: any Encoder) throws {
+            try start()
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try finish()
+          }
+        }
+
+        extension User: Codable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+          }
+        }
+        """
+    )
+  }
+}

--- a/Tests/CodableKitTests/CodableMacroTests+diagnostics.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+diagnostics.swift
@@ -57,12 +57,10 @@ import Testing
           var ignored: String = "Hello World"
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -78,7 +76,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -108,12 +105,10 @@ import Testing
           static let staticProperty = "Hello World"
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -129,7 +124,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -162,12 +156,10 @@ import Testing
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -183,7 +175,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """,
@@ -219,12 +210,10 @@ import Testing
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -240,7 +229,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """,
@@ -272,12 +260,10 @@ import Testing
           static var address: String = "A"
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -293,7 +279,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """,
@@ -341,10 +326,8 @@ import Testing
           public private(set) var expireTime: Date?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encodeIfPresent(_expireTime, forKey: ._expireTime)
-            try didEncode(to: encoder)
           }
         }
 
@@ -356,7 +339,6 @@ import Testing
           public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             _expireTime = (try? container.decodeIfPresent(Int?.self, forKey: ._expireTime)) ?? nil
-            try didDecode(from: decoder)
           }
         }
         """

--- a/Tests/CodableKitTests/CodableMacroTests+hooks.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+hooks.swift
@@ -1,0 +1,93 @@
+//
+//  CodableMacroTests+hooks.swift
+//  CodableKit
+//
+//  Created by AI on 2025/10/02.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import Testing
+
+@Suite struct CodableHooksExpansionTestsForStruct {
+  @Test func combinedAnnotatedHooksRunInOrder() throws {
+    assertMacro(
+      """
+      @Codable
+      public struct User {
+        let id: UUID
+        let name: String
+
+        @CodableHook(.willDecode)
+        static func pre1() throws {}
+        @CodableHook(.willDecode)
+        static func pre2(from decoder: any Decoder) throws {}
+        @CodableHook(.didDecode)
+        mutating func post1() throws {}
+        @CodableHook(.didDecode)
+        mutating func post2(from decoder: any Decoder) throws {}
+        @CodableHook(.willEncode)
+        func start() throws {}
+        @CodableHook(.willEncode)
+        func ready(to encoder: any Encoder) throws {}
+        @CodableHook(.didEncode)
+        func finish() throws {}
+        @CodableHook(.didEncode)
+        func end(to encoder: any Encoder) throws {}
+      }
+      """,
+      expandedSource: """
+        public struct User {
+          let id: UUID
+          let name: String
+
+          @CodableHook(.willDecode)
+          static func pre1() throws {}
+          @CodableHook(.willDecode)
+          static func pre2(from decoder: any Decoder) throws {}
+          @CodableHook(.didDecode)
+          mutating func post1() throws {}
+          @CodableHook(.didDecode)
+          mutating func post2(from decoder: any Decoder) throws {}
+          @CodableHook(.willEncode)
+          func start() throws {}
+          @CodableHook(.willEncode)
+          func ready(to encoder: any Encoder) throws {}
+          @CodableHook(.didEncode)
+          func finish() throws {}
+          @CodableHook(.didEncode)
+          func end(to encoder: any Encoder) throws {}
+
+          public func encode(to encoder: any Encoder) throws {
+            try start()
+            try ready(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try finish()
+            try end(to: encoder)
+          }
+        }
+
+        extension User: Codable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+          }
+
+          public init(from decoder: any Decoder) throws {
+            try Self.pre1()
+            try Self.pre2(from: decoder)
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            try post1()
+            try post2(from: decoder)
+          }
+        }
+        """
+    )
+  }
+}

--- a/Tests/CodableKitTests/CodableMacroTests+keys.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+keys.swift
@@ -31,12 +31,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: EncodeKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -57,7 +55,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -83,12 +80,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -104,7 +99,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -129,12 +123,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: EncodeKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -155,7 +147,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -170,7 +161,7 @@ import Testing
           @Codable public struct ColorValue: Sendable {
               @CodableKey("light") private let lightHex: String
               @CodableKey("dark") private let darkHex: String
-      
+
               public subscript(_ scheme: ColorScheme) -> String {
                   switch scheme {
                   case .light: lightHex
@@ -194,7 +185,7 @@ import Testing
             public struct ColorValue: Sendable {
                 private let lightHex: String
                 private let darkHex: String
-        
+
                 public subscript(_ scheme: ColorScheme) -> String {
                     switch scheme {
                     case .light: lightHex
@@ -209,20 +200,16 @@ import Testing
                 }
 
               public func encode(to encoder: any Encoder) throws {
-                try willEncode(to: encoder)
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encode(lightHex, forKey: .lightHex)
                 try container.encode(darkHex, forKey: .darkHex)
-                try didEncode(to: encoder)
               }
             }
             public let name: String
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(name, forKey: .name)
-            try didEncode(to: encoder)
           }
         }
 
@@ -235,7 +222,6 @@ import Testing
             let container = try decoder.container(keyedBy: CodingKeys.self)
             lightHex = try container.decode(String.self, forKey: .lightHex)
             darkHex = try container.decode(String.self, forKey: .darkHex)
-            try didDecode(from: decoder)
           }
         }
 
@@ -246,7 +232,6 @@ import Testing
           public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             name = try container.decode(String.self, forKey: .name)
-            try didDecode(from: decoder)
           }
         }
         """)

--- a/Tests/CodableKitTests/CodableMacroTests+struct.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+struct.swift
@@ -29,12 +29,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -50,7 +48,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -76,12 +73,10 @@ import Testing
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -97,7 +92,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """
@@ -129,13 +123,11 @@ import Testing
           var level: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(level, forKey: .level)
-            try didEncode(to: encoder)
           }
         }
 
@@ -153,7 +145,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
             level = try container.decodeIfPresent(Int.self, forKey: .level) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """
@@ -179,12 +170,10 @@ import Testing
           var age: Int? = 24
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -200,7 +189,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """
@@ -229,12 +217,10 @@ import Testing
           let thisPropertyWillBeIgnored: String
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -250,7 +236,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """
@@ -279,13 +264,11 @@ import Testing
           let explicitNil: String?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
-            try didEncode(to: encoder)
           }
         }
 
@@ -303,7 +286,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
-            try didDecode(from: decoder)
           }
         }
         """
@@ -334,12 +316,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -355,7 +335,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -391,12 +370,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -412,7 +389,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -449,7 +425,6 @@ import Testing
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -467,7 +442,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -497,7 +471,6 @@ import Testing
                 )
               )
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -534,7 +507,6 @@ import Testing
           let room: Room?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -554,7 +526,6 @@ import Testing
                 )
               }
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -578,7 +549,6 @@ import Testing
             } else {
               room = nil
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -615,7 +585,6 @@ import Testing
           var room: Room = Room(id: UUID(), name: "Hello")
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -633,7 +602,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -657,7 +625,6 @@ import Testing
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -694,7 +661,6 @@ import Testing
           var room: Room?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -714,7 +680,6 @@ import Testing
                 )
               }
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -738,7 +703,6 @@ import Testing
             } else {
               room = nil
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -775,7 +739,6 @@ import Testing
           var room: Room?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -795,7 +758,6 @@ import Testing
                 )
               }
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -819,7 +781,6 @@ import Testing
             } else {
               room = nil
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -856,7 +817,6 @@ import Testing
           var room: Room = Room(id: UUID(), name: "Hello")
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -874,7 +834,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -898,7 +857,6 @@ import Testing
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -937,13 +895,11 @@ import Testing
           var role: Role = .unknown
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
-            try didEncode(to: encoder)
           }
         }
 
@@ -961,7 +917,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
-            try didDecode(from: decoder)
           }
         }
         """

--- a/Tests/CodableKitTests/CodableMacroTests+transcode.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+transcode.swift
@@ -34,7 +34,6 @@ import Testing
           var room: Room?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             if let roomUnwrapped = room {
@@ -51,7 +50,6 @@ import Testing
                 )
               }
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -69,7 +67,6 @@ import Testing
             } else {
               room = nil
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -98,7 +95,6 @@ import Testing
           var room: Room?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             let roomRawData = try __ckEncoder.encode(room)
@@ -113,7 +109,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -131,7 +126,6 @@ import Testing
             } else {
               room = nil
             }
-            try didDecode(from: decoder)
           }
         }
         """

--- a/Tests/CodableKitTests/NestedCodableTests.swift
+++ b/Tests/CodableKitTests/NestedCodableTests.swift
@@ -26,14 +26,12 @@ func testNestedCodable() throws {
         let name: String
 
         internal func encode(to encoder: any Encoder) throws {
-          try willEncode(to: encoder)
           var container = encoder.container(keyedBy: CodingKeys.self)
           var dataContainer = container.nestedContainer(keyedBy: DataKeys.self, forKey: .data)
           var profileContainer = container.nestedContainer(keyedBy: ProfileKeys.self, forKey: .profile)
           try dataContainer.encode(id, forKey: .id)
           var infoContainer = profileContainer.nestedContainer(keyedBy: InfoKeys.self, forKey: .info)
           try infoContainer.encode(name, forKey: .name)
-          try didEncode(to: encoder)
         }
       }
 
@@ -58,7 +56,6 @@ func testNestedCodable() throws {
           id = try dataContainer.decode(Int.self, forKey: .id)
           let infoContainer = try profileContainer.nestedContainer(keyedBy: InfoKeys.self, forKey: .info)
           name = try infoContainer.decode(String.self, forKey: .name)
-          try didDecode(from: decoder)
         }
       }
       """

--- a/Tests/CodableKitTests/TypeInferenceTests.swift
+++ b/Tests/CodableKitTests/TypeInferenceTests.swift
@@ -36,7 +36,6 @@ struct TypeInferenceTests {
           var negativeDoubleLiteral = -123.456
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(strLiteral, forKey: .strLiteral)
             try container.encode(intLiteral, forKey: .intLiteral)
@@ -44,7 +43,6 @@ struct TypeInferenceTests {
             try container.encode(boolLiteral, forKey: .boolLiteral)
             try container.encode(negativeIntLiteral, forKey: .negativeIntLiteral)
             try container.encode(negativeDoubleLiteral, forKey: .negativeDoubleLiteral)
-            try didEncode(to: encoder)
           }
         }
 
@@ -66,7 +64,6 @@ struct TypeInferenceTests {
             boolLiteral = try container.decodeIfPresent(Bool.self, forKey: .boolLiteral) ?? true
             negativeIntLiteral = try container.decodeIfPresent(Int.self, forKey: .negativeIntLiteral) ?? -123
             negativeDoubleLiteral = try container.decodeIfPresent(Double.self, forKey: .negativeDoubleLiteral) ?? -123.456
-            try didDecode(from: decoder)
           }
         }
         """
@@ -96,14 +93,12 @@ struct TypeInferenceTests {
           var numberArrayLiteral = [1, 2.0, 3]
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(arrayLiteral, forKey: .arrayLiteral)
             try container.encode(stringArrayLiteral, forKey: .stringArrayLiteral)
             try container.encode(boolArrayLiteral, forKey: .boolArrayLiteral)
             try container.encode(doubleArrayLiteral, forKey: .doubleArrayLiteral)
             try container.encode(numberArrayLiteral, forKey: .numberArrayLiteral)
-            try didEncode(to: encoder)
           }
         }
 
@@ -123,7 +118,6 @@ struct TypeInferenceTests {
             boolArrayLiteral = try container.decodeIfPresent([Bool].self, forKey: .boolArrayLiteral) ?? [true, false]
             doubleArrayLiteral = try container.decodeIfPresent([Double].self, forKey: .doubleArrayLiteral) ?? [1.0, 2.0, 3.0]
             numberArrayLiteral = try container.decodeIfPresent([Double].self, forKey: .numberArrayLiteral) ?? [1, 2.0, 3]
-            try didDecode(from: decoder)
           }
         }
         """

--- a/Tests/DecodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -35,7 +35,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -74,7 +73,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -114,7 +112,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -153,7 +150,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -195,7 +191,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -238,7 +233,6 @@ import Testing
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -283,7 +277,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -332,7 +325,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -395,7 +387,6 @@ import Testing
               )
             }
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -459,7 +450,6 @@ import Testing
               )
             }
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -525,7 +515,6 @@ import Testing
               room = Room(id: UUID(), name: "Hello")
             }
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -579,7 +568,6 @@ import Testing
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
             try super.init(from: decoder)
-            try didDecode(from: decoder)
           }
         }
 
@@ -619,7 +607,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             super.init()
-            try didDecode(from: decoder)
           }
         }
 

--- a/Tests/DecodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+class.swift
@@ -33,7 +33,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
 
@@ -70,7 +69,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
 
@@ -109,7 +107,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
 
@@ -147,7 +144,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
 
@@ -188,7 +184,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
 
@@ -230,7 +225,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
-            try didDecode(from: decoder)
           }
         }
 
@@ -274,7 +268,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
 
@@ -322,7 +315,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
 
@@ -384,7 +376,6 @@ import Testing
                 )
               )
             }
-            try didDecode(from: decoder)
           }
         }
 
@@ -447,7 +438,6 @@ import Testing
                 )
               )
             }
-            try didDecode(from: decoder)
           }
         }
 
@@ -512,7 +502,6 @@ import Testing
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
-            try didDecode(from: decoder)
           }
         }
 
@@ -565,7 +554,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
-            try didDecode(from: decoder)
           }
         }
 
@@ -604,7 +592,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
 

--- a/Tests/DecodableKitTests/CodableMacroTests+diagnostics.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+diagnostics.swift
@@ -70,7 +70,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -112,7 +111,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -157,7 +155,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """,
@@ -205,7 +202,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """,
@@ -249,7 +245,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """,

--- a/Tests/DecodableKitTests/CodableMacroTests+hooks.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+hooks.swift
@@ -94,4 +94,86 @@ import Testing
         """
     )
   }
+
+  @Test func staticWillDecodeHookWithoutParamsIncluded() throws {
+    assertMacro(
+      """
+      @Decodable
+      public struct User {
+        let id: UUID
+        let name: String
+        let age: Int
+
+        @CodableHook(.willDecode)
+        static func pre() throws {}
+      }
+      """,
+      expandedSource: """
+        public struct User {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          @CodableHook(.willDecode)
+          static func pre() throws {}
+        }
+
+        extension User: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+
+          public init(from decoder: any Decoder) throws {
+            try Self.pre()
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            age = try container.decode(Int.self, forKey: .age)
+          }
+        }
+        """
+    )
+  }
+
+  @Test func conventionalDidDecodeWithoutAnnotationParameterless() throws {
+    assertMacro(
+      """
+      @Decodable
+      public struct User {
+        let id: UUID
+        let name: String
+        let age: Int
+
+        mutating func didDecode() throws {}
+      }
+      """,
+      expandedSource: """
+        public struct User {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          mutating func didDecode() throws {}
+        }
+
+        extension User: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+
+          public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            age = try container.decode(Int.self, forKey: .age)
+            try didDecode()
+          }
+        }
+        """
+    )
+  }
 }

--- a/Tests/DecodableKitTests/CodableMacroTests+hooks.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+hooks.swift
@@ -63,7 +63,7 @@ import Testing
         var age: Int
 
         @CodableHook(.didDecode)
-        mutating func post(from decoder: any Decoder) throws { age += 1 }
+        mutating func post() throws { age += 1 }
       }
       """,
       expandedSource: """
@@ -73,7 +73,7 @@ import Testing
           var age: Int
 
           @CodableHook(.didDecode)
-          mutating func post(from decoder: any Decoder) throws { age += 1 }
+          mutating func post() throws { age += 1 }
         }
 
         extension User: Decodable {
@@ -88,7 +88,7 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try post(from: decoder)
+            try post()
           }
         }
         """

--- a/Tests/DecodableKitTests/CodableMacroTests+hooks.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+hooks.swift
@@ -12,6 +12,47 @@ import SwiftSyntaxMacrosTestSupport
 import Testing
 
 @Suite struct DecodableHooksExpansionTests {
+  @Test func staticWillDecodeHookIncludedBeforeDecoding() throws {
+    assertMacro(
+      """
+      @Decodable
+      public struct User {
+        let id: UUID
+        let name: String
+        let age: Int
+
+        @CodableHook(.willDecode)
+        static func pre(from decoder: any Decoder) throws {}
+      }
+      """,
+      expandedSource: """
+        public struct User {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          @CodableHook(.willDecode)
+          static func pre(from decoder: any Decoder) throws {}
+        }
+
+        extension User: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+
+          public init(from decoder: any Decoder) throws {
+            try Self.pre(from: decoder)
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            age = try container.decode(Int.self, forKey: .age)
+          }
+        }
+        """
+    )
+  }
   @Test func structDidDecodeHookIncludedWhenPresent() throws {
     assertMacro(
       """
@@ -21,9 +62,8 @@ import Testing
         let name: String
         var age: Int
 
-        mutating func didDecode(from decoder: any Decoder) throws {
-          age += 1
-        }
+        @CodableHook(.didDecode)
+        mutating func post(from decoder: any Decoder) throws { age += 1 }
       }
       """,
       expandedSource: """
@@ -32,9 +72,8 @@ import Testing
           let name: String
           var age: Int
 
-          mutating func didDecode(from decoder: any Decoder) throws {
-            age += 1
-          }
+          @CodableHook(.didDecode)
+          mutating func post(from decoder: any Decoder) throws { age += 1 }
         }
 
         extension User: Decodable {
@@ -49,11 +88,10 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
+            try post(from: decoder)
           }
         }
         """
     )
   }
 }
-

--- a/Tests/DecodableKitTests/CodableMacroTests+hooks.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+hooks.swift
@@ -1,0 +1,59 @@
+//
+//  CodableMacroTests+hooks.swift
+//  CodableKit
+//
+//  Created by AI on 2025/10/02.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import Testing
+
+@Suite struct DecodableHooksExpansionTests {
+  @Test func structDidDecodeHookIncludedWhenPresent() throws {
+    assertMacro(
+      """
+      @Decodable
+      public struct User {
+        let id: UUID
+        let name: String
+        var age: Int
+
+        mutating func didDecode(from decoder: any Decoder) throws {
+          age += 1
+        }
+      }
+      """,
+      expandedSource: """
+        public struct User {
+          let id: UUID
+          let name: String
+          var age: Int
+
+          mutating func didDecode(from decoder: any Decoder) throws {
+            age += 1
+          }
+        }
+
+        extension User: Decodable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+
+          public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            age = try container.decode(Int.self, forKey: .age)
+            try didDecode(from: decoder)
+          }
+        }
+        """
+    )
+  }
+}
+

--- a/Tests/DecodableKitTests/CodableMacroTests+keys.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+keys.swift
@@ -42,7 +42,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -106,7 +105,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """

--- a/Tests/DecodableKitTests/CodableMacroTests+lossy.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+lossy.swift
@@ -41,7 +41,6 @@ import Testing
             values = valuesLossyWrapper.elements
             let values2LossyWrapper = try container.decode(LossyArray<String>.self, forKey: .values2)
             values2 = values2LossyWrapper.elements
-            try didDecode(from: decoder)
           }
         }
         """
@@ -75,7 +74,6 @@ import Testing
             } else {
               values = nil
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -109,7 +107,6 @@ import Testing
             } else {
               values = [1, 2]
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -143,7 +140,6 @@ import Testing
             } else {
               ids = nil
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -185,7 +181,6 @@ import Testing
                 )
               )
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -221,7 +216,6 @@ import Testing
             } else {
               values = [1, 2]
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -257,7 +251,6 @@ import Testing
             map = mapLossyWrapper.elements
             let otherLossyWrapper = try container.decode(LossyDictionary<String, Int>.self, forKey: .other)
             other = otherLossyWrapper.elements
-            try didDecode(from: decoder)
           }
         }
         """
@@ -291,7 +284,6 @@ import Testing
             } else {
               map = nil
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -325,7 +317,6 @@ import Testing
             } else {
               map = ["a": 1]
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -367,7 +358,6 @@ import Testing
                 )
               )
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -403,7 +393,6 @@ import Testing
             } else {
               map = [:]
             }
-            try didDecode(from: decoder)
           }
         }
         """

--- a/Tests/DecodableKitTests/CodableMacroTests+struct.swift
+++ b/Tests/DecodableKitTests/CodableMacroTests+struct.swift
@@ -42,7 +42,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -80,7 +79,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """
@@ -119,7 +117,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """
@@ -157,7 +154,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """
@@ -198,7 +194,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
-            try didDecode(from: decoder)
           }
         }
         """
@@ -241,7 +236,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decodeIfPresent(Int?.self, forKey: .age) ?? 24
             explicitNil = try container.decodeIfPresent(String?.self, forKey: .explicitNil) ?? nil
-            try didDecode(from: decoder)
           }
         }
         """
@@ -284,7 +278,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -332,7 +325,6 @@ import Testing
             id = try container.decode(UUID.self, forKey: .id)
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -395,7 +387,6 @@ import Testing
                 )
               )
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -458,7 +449,6 @@ import Testing
                 )
               )
             }
-            try didDecode(from: decoder)
           }
         }
         """,
@@ -523,7 +513,6 @@ import Testing
             } else {
               room = Room(id: UUID(), name: "Hello")
             }
-            try didDecode(from: decoder)
           }
         }
         """
@@ -576,7 +565,6 @@ import Testing
             name = try container.decode(String.self, forKey: .name)
             age = try container.decode(Int.self, forKey: .age)
             role = (try? container.decodeIfPresent(Role.self, forKey: .role)) ?? .unknown
-            try didDecode(from: decoder)
           }
         }
         """

--- a/Tests/EncodableKitTests/CodableMacroTests+class+inheritance.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+class+inheritance.swift
@@ -30,13 +30,11 @@ import Testing
           let age: Int
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -70,13 +68,11 @@ import Testing
           var age: Int = 24
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -111,13 +107,11 @@ import Testing
           var age: Int = 24
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -151,13 +145,11 @@ import Testing
           var age: Int? = 24
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -194,13 +186,11 @@ import Testing
           let thisPropertyWillBeIgnored: String
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -237,14 +227,12 @@ import Testing
           let explicitNil: String?
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -284,13 +272,11 @@ import Testing
           let age: Int
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -334,13 +320,11 @@ import Testing
           let age: Int
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -385,7 +369,6 @@ import Testing
           let room: Room
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -404,7 +387,6 @@ import Testing
               )
             }
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -450,7 +432,6 @@ import Testing
           let room: Room
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -469,7 +450,6 @@ import Testing
               )
             }
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -523,7 +503,6 @@ import Testing
           var room: Room = Room(id: UUID(), name: "Hello")
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -542,7 +521,6 @@ import Testing
               )
             }
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -590,14 +568,12 @@ import Testing
           var role: Role = .unknown
 
           public override func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
             try super.encode(to: encoder)
-            try didEncode(to: encoder)
           }
         }
 
@@ -632,12 +608,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/EncodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+class.swift
@@ -29,12 +29,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -67,12 +65,10 @@ import Testing
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -107,12 +103,10 @@ import Testing
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -146,12 +140,10 @@ import Testing
           var age: Int? = 24
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -188,12 +180,10 @@ import Testing
           let thisPropertyWillBeIgnored: String
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -230,13 +220,11 @@ import Testing
           let explicitNil: String?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
-            try didEncode(to: encoder)
           }
         }
 
@@ -276,12 +264,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -325,12 +311,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -375,7 +359,6 @@ import Testing
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -393,7 +376,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -439,7 +421,6 @@ import Testing
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -457,7 +438,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -512,7 +492,6 @@ import Testing
           var room: Room = Room(id: UUID(), name: "Hello")
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -530,7 +509,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -578,13 +556,11 @@ import Testing
           var role: Role = .unknown
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
-            try didEncode(to: encoder)
           }
         }
 
@@ -619,12 +595,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/EncodableKitTests/CodableMacroTests+diagnostics.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+diagnostics.swift
@@ -57,12 +57,10 @@ import Testing
           var ignored: String = "Hello World"
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -100,12 +98,10 @@ import Testing
           static let staticProperty = "Hello World"
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -146,12 +142,10 @@ import Testing
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -195,12 +189,10 @@ import Testing
           }
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -240,12 +232,10 @@ import Testing
           static var address: String = "A"
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/EncodableKitTests/CodableMacroTests+hooks.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+hooks.swift
@@ -1,0 +1,58 @@
+//
+//  CodableMacroTests+hooks.swift
+//  CodableKit
+//
+//  Created by AI on 2025/10/02.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import Testing
+
+@Suite struct EncodableHooksExpansionTests {
+  @Test func classWillAndDidEncodeHooksIncludedWhenPresent() throws {
+    assertMacro(
+      """
+      @Encodable
+      public class User {
+        let id: UUID
+        let name: String
+        let age: Int
+
+        func willEncode(to encoder: any Encoder) throws {}
+        func didEncode(to encoder: any Encoder) throws {}
+      }
+      """,
+      expandedSource: """
+        public class User {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          func willEncode(to encoder: any Encoder) throws {}
+          func didEncode(to encoder: any Encoder) throws {}
+
+          public func encode(to encoder: any Encoder) throws {
+            try willEncode(to: encoder)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try container.encode(age, forKey: .age)
+            try didEncode(to: encoder)
+          }
+        }
+
+        extension User: Encodable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+        }
+        """
+    )
+  }
+}
+

--- a/Tests/EncodableKitTests/CodableMacroTests+hooks.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+hooks.swift
@@ -22,10 +22,10 @@ import Testing
         let age: Int
 
         @CodableHook(.willEncode)
-        func prepare(to encoder: any Encoder) throws {}
+        func prepare() throws {}
 
         @CodableHook(.didEncode)
-        func finish(to encoder: any Encoder) throws {}
+        func finish() throws {}
       }
       """,
       expandedSource: """
@@ -35,18 +35,18 @@ import Testing
           let age: Int
 
           @CodableHook(.willEncode)
-          func prepare(to encoder: any Encoder) throws {}
+          func prepare() throws {}
 
           @CodableHook(.didEncode)
-          func finish(to encoder: any Encoder) throws {}
+          func finish() throws {}
 
           public func encode(to encoder: any Encoder) throws {
-            try prepare(to: encoder)
+            try prepare()
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try finish(to: encoder)
+            try finish()
           }
         }
 

--- a/Tests/EncodableKitTests/CodableMacroTests+hooks.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+hooks.swift
@@ -21,8 +21,11 @@ import Testing
         let name: String
         let age: Int
 
-        func willEncode(to encoder: any Encoder) throws {}
-        func didEncode(to encoder: any Encoder) throws {}
+        @CodableHook(.willEncode)
+        func prepare(to encoder: any Encoder) throws {}
+
+        @CodableHook(.didEncode)
+        func finish(to encoder: any Encoder) throws {}
       }
       """,
       expandedSource: """
@@ -31,16 +34,19 @@ import Testing
           let name: String
           let age: Int
 
-          func willEncode(to encoder: any Encoder) throws {}
-          func didEncode(to encoder: any Encoder) throws {}
+          @CodableHook(.willEncode)
+          func prepare(to encoder: any Encoder) throws {}
+
+          @CodableHook(.didEncode)
+          func finish(to encoder: any Encoder) throws {}
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
+            try prepare(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
+            try finish(to: encoder)
           }
         }
 
@@ -55,4 +61,3 @@ import Testing
     )
   }
 }
-

--- a/Tests/EncodableKitTests/CodableMacroTests+hooks.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+hooks.swift
@@ -60,4 +60,47 @@ import Testing
         """
     )
   }
+
+  @Test func conventionalWillAndDidEncodeWithoutAnnotationsParameterless() throws {
+    assertMacro(
+      """
+      @Encodable
+      public class User {
+        let id: UUID
+        let name: String
+        let age: Int
+
+        func willEncode() throws {}
+        func didEncode() throws {}
+      }
+      """,
+      expandedSource: """
+        public class User {
+          let id: UUID
+          let name: String
+          let age: Int
+
+          func willEncode() throws {}
+          func didEncode() throws {}
+
+          public func encode(to encoder: any Encoder) throws {
+            try willEncode()
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try container.encode(age, forKey: .age)
+            try didEncode()
+          }
+        }
+
+        extension User: Encodable {
+          enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+          }
+        }
+        """
+    )
+  }
 }

--- a/Tests/EncodableKitTests/CodableMacroTests+keys.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+keys.swift
@@ -30,12 +30,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -95,12 +93,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/EncodableKitTests/CodableMacroTests+lossy.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+lossy.swift
@@ -29,11 +29,9 @@ import Testing
           let values2: Array<String>
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(values, forKey: .values)
             try container.encode(values2, forKey: .values2)
-            try didEncode(to: encoder)
           }
         }
 
@@ -61,10 +59,8 @@ import Testing
           let values: [String]?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encodeIfPresent(values, forKey: .values)
-            try didEncode(to: encoder)
           }
         }
 
@@ -91,10 +87,8 @@ import Testing
           var values: [Int] = [1, 2]
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(values, forKey: .values)
-            try didEncode(to: encoder)
           }
         }
 
@@ -121,10 +115,8 @@ import Testing
           let ids: Set<Int>?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encodeIfPresent(ids, forKey: .ids)
-            try didEncode(to: encoder)
           }
         }
 
@@ -151,7 +143,6 @@ import Testing
           let values: [Int]
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             let valuesRawData = try __ckEncoder.encode(values)
@@ -166,7 +157,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -193,7 +183,6 @@ import Testing
           var values: [Int] = [1, 2]
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             let valuesRawData = try __ckEncoder.encode(values)
@@ -208,7 +197,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/EncodableKitTests/CodableMacroTests+struct.swift
+++ b/Tests/EncodableKitTests/CodableMacroTests+struct.swift
@@ -30,12 +30,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -69,12 +67,10 @@ import Testing
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -109,12 +105,10 @@ import Testing
           var age: Int = 24
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -148,12 +142,10 @@ import Testing
           var age: Int? = 24
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -190,12 +182,10 @@ import Testing
           let thisPropertyWillBeIgnored: String
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -232,13 +222,11 @@ import Testing
           let explicitNil: String?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encodeIfPresent(age, forKey: .age)
             try container.encode(explicitNil, forKey: .explicitNil)
-            try didEncode(to: encoder)
           }
         }
 
@@ -278,12 +266,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -327,12 +313,10 @@ import Testing
           let age: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
-            try didEncode(to: encoder)
           }
         }
 
@@ -377,7 +361,6 @@ import Testing
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -395,7 +378,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -441,7 +423,6 @@ import Testing
           let room: Room
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -459,7 +440,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -513,7 +493,6 @@ import Testing
           var room: Room = Room(id: UUID(), name: "Hello")
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             let __ckEncoder = JSONEncoder()
             try container.encode(id, forKey: .id)
@@ -531,7 +510,6 @@ import Testing
                 )
               )
             }
-            try didEncode(to: encoder)
           }
         }
 
@@ -579,13 +557,11 @@ import Testing
           var role: Role = .unknown
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
             try container.encode(name, forKey: .name)
             try container.encode(age, forKey: .age)
             try container.encode(role, forKey: .role)
-            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/EncodableKitTests/CodingTransformerEncodeTests.swift
+++ b/Tests/EncodableKitTests/CodingTransformerEncodeTests.swift
@@ -32,10 +32,8 @@ import Testing
           var count: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try __ckEncodeTransformed(transformer: IntFromString(), value: count, into: &container, forKey: .count)
-            try didEncode(to: encoder)
           }
         }
 
@@ -70,10 +68,8 @@ import Testing
           var count: Int?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try __ckEncodeTransformedIfPresent(transformer: IntFromString(), value: count, into: &container, forKey: .count, explicitNil: false)
-            try didEncode(to: encoder)
           }
         }
 
@@ -108,10 +104,8 @@ import Testing
           var count: Int?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try __ckEncodeTransformedIfPresent(transformer: IntFromString(), value: count, into: &container, forKey: .count, explicitNil: true)
-            try didEncode(to: encoder)
           }
         }
 

--- a/Tests/TransformerTests/CodingTransformerTests.swift
+++ b/Tests/TransformerTests/CodingTransformerTests.swift
@@ -34,10 +34,8 @@ import Testing
           var count: Int
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try __ckEncodeTransformed(transformer: IntFromString(), value: count, into: &container, forKey: .count)
-            try didEncode(to: encoder)
           }
         }
 
@@ -49,7 +47,6 @@ import Testing
           public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             count = try __ckDecodeTransformed(transformer: IntFromString(), from: container, forKey: .count, useDefaultOnFailure: false)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -78,10 +75,8 @@ import Testing
           var count: Int?
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try __ckEncodeTransformedIfPresent(transformer: IntFromString(), value: count, into: &container, forKey: .count, explicitNil: false)
-            try didEncode(to: encoder)
           }
         }
 
@@ -93,7 +88,6 @@ import Testing
           public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             count = try __ckDecodeTransformedIfPresent(transformer: IntFromString(), from: container, forKey: .count, useDefaultOnFailure: false)
-            try didDecode(from: decoder)
           }
         }
         """
@@ -122,10 +116,8 @@ import Testing
           var count: Int = 42
 
           public func encode(to encoder: any Encoder) throws {
-            try willEncode(to: encoder)
             var container = encoder.container(keyedBy: CodingKeys.self)
             try __ckEncodeTransformed(transformer: IntFromString(), value: count, into: &container, forKey: .count)
-            try didEncode(to: encoder)
           }
         }
 
@@ -137,7 +129,6 @@ import Testing
           public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             count = (try __ckDecodeTransformedIfPresent(transformer: IntFromString(), from: container, forKey: .count, useDefaultOnFailure: true, defaultValue: 42)) ?? 42
-            try didDecode(from: decoder)
           }
         }
         """


### PR DESCRIPTION
This pull request introduces a new, annotation-based lifecycle hook system for encoding and decoding in CodableKit, replacing the old convention-based approach. It adds the `@CodableHook` macro for explicit hook registration, updates macro code generation to invoke annotated hooks at the correct stages, and revises documentation and examples to reflect these changes. The update also removes legacy protocol conformances and clarifies why certain hooks (like instance `willDecode`) are not supported.

**Lifecycle Hook System Overhaul**

* Introduced the `@CodableHook` macro and `HookStage` enum (`.willDecode`, `.didDecode`, `.willEncode`, `.didEncode`) to allow explicit annotation of methods for invocation during encoding/decoding lifecycle stages. This enables multiple hooks per stage, called in declaration order, and provides compile-time safety and clarity. (`Sources/CodableKit/CodableHook.swift` [Sources/CodableKit/CodableHook.swiftR1-R54](diffhunk://#diff-65744f0bdbd2c3934fe4002031c13cc1370720abf5dd617dd663d04b788bddcbR1-R54))
* Updated macro code generation to detect and invoke all annotated hooks at the appropriate points in `init(from:)` and `encode(to:)`, supporting both static and instance methods as required by Swift's initialization rules. (`Sources/CodableKitMacros/CodableMacro.swift` [[1]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4R34) [[2]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4L90-R92) [[3]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4R137) [[4]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4L185-R189) [[5]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4L200-R205) [[6]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4L223-R229) [[7]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4R243-R252) [[8]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4L249-R272) [[9]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4L259-R283) [[10]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4L272-R303) [[11]](diffhunk://#diff-6b2b83f546e4e2ba9344c604ece9603c71fab5c83868240f412a4243f31e7fc4L282-R320); `Sources/CodableKitMacros/CodeGenCore.swift` [[12]](diffhunk://#diff-ff70c8cdcab694fe73d53c4ca01b432d14d33955ab3ec54eb7ff2b24b1e465cfR34) [[13]](diffhunk://#diff-ff70c8cdcab694fe73d53c4ca01b432d14d33955ab3ec54eb7ff2b24b1e465cfR48-R64)

**Documentation and Example Updates**

* Revised the README and inline doc comments to document the new hook system, provide migration guidance, and explain the rationale for static-only `willDecode` hooks. This includes new usage examples and a clear explanation of hook annotation benefits. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R68) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R219-R222) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R232-R255); `Sources/CodableKit/CodableKit.swift` [[4]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L30-R30) [[5]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L43-L52) [[6]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L141) [[7]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L153-R149) [[8]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L181-R177) [[9]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L194) [[10]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L275) [[11]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L287-R281) [[12]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L315-R309) [[13]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L324-L329) [[14]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L413) [[15]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L425-R416)

**Legacy API Cleanup**

* Removed legacy protocol conformances (`CodableHooks`, `DecodingHooks`, `EncodingHooks`) from macro-generated code, as hook support is now annotation-driven. (`Sources/CodableKit/CodableKit.swift` [[1]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L141) [[2]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L153-R149) [[3]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L275) [[4]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L287-R281) [[5]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L413) [[6]](diffhunk://#diff-b4bb4af83affff4e0c7c69e0153221fa5dfd5532193913b59efd78c6d99030d5L425-R416)

These changes modernize and clarify the lifecycle hook system, making it safer, more flexible, and easier to use and document.