### PR TITLE
fix(core): promote private Codable witnesses to fileprivate

### DIFF
--- a/Sources/CodableKitMacros/CodableMacro.swift
+++ b/Sources/CodableKitMacros/CodableMacro.swift
@@ -128,7 +128,7 @@ public struct CodableMacro: ExtensionMacro {
               DeclSyntax(
                 genInitDecoderDecl(
                   from: properties,
-                  modifiers: [accessModifier],
+                  modifiers: [accessModifier.witnessSafe],
                   codableOptions: codableOptions,
                   hasSuper: false,
                   tree: usingTree,
@@ -196,8 +196,8 @@ extension CodableMacro: MemberMacro {
       encodeTree = sharedTree
     }
 
-    var decodeModifiers = [accessModifier]
-    var encodeModifiers = [accessModifier]
+    var decodeModifiers = [accessModifier.witnessSafe]
+    var encodeModifiers = [accessModifier.witnessSafe]
 
     // If the structure is a class and has a superclass, this should be set to true.
     // This flag is used to determine if the encode and decode methods

--- a/Sources/CodableKitMacros/SwiftSyntaxHelper.swift
+++ b/Sources/CodableKitMacros/SwiftSyntaxHelper.swift
@@ -46,6 +46,20 @@ extension TokenSyntax {
   }
 }
 
+extension DeclModifierSyntax {
+  /// The access modifier to apply to synthesized protocol witnesses (`init(from:)` / `encode(to:)`).
+  ///
+  /// A `private` member matching a protocol requirement must be "as accessible as its enclosing
+  /// type". For a `private` type the enclosing type is effectively `fileprivate`, so a `private`
+  /// witness fails to satisfy the `Codable` requirement. Promoting `private` to `fileprivate`
+  /// mirrors what the compiler does for its own synthesized `Codable` conformance. All other
+  /// access levels are already as accessible as the type and are left unchanged.
+  internal var witnessSafe: DeclModifierSyntax {
+    guard name.text == TokenSyntax.keyword(.private).text else { return self }
+    return with(\.name, .keyword(.fileprivate, leadingTrivia: name.leadingTrivia, trailingTrivia: name.trailingTrivia))
+  }
+}
+
 extension LabeledExprListSyntax {
   func getExpr(label: String?) -> LabeledExprSyntax? {
     first(where: { $0.label?.text == label })

--- a/Tests/CodableKitTests/CodableMacroTests+class.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+class.swift
@@ -54,6 +54,38 @@ import Testing
     )
   }
 
+  @Test func privateClassPromotesWitnessesToFileprivate() throws {
+    assertMacro(
+      """
+      @Codable
+      private class Account {
+        let token: String
+      }
+      """,
+      expandedSource: """
+        private class Account {
+          let token: String
+
+          fileprivate required init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            token = try container.decode(String.self, forKey: .token)
+          }
+
+          fileprivate func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(token, forKey: .token)
+          }
+        }
+
+        extension Account: Codable {
+          enum CodingKeys: String, CodingKey {
+            case token
+          }
+        }
+        """
+    )
+  }
+
   @Test func macroWithDefaultValue() throws {
 
     assertMacro(

--- a/Tests/CodableKitTests/CodableMacroTests+struct.swift
+++ b/Tests/CodableKitTests/CodableMacroTests+struct.swift
@@ -96,6 +96,75 @@ import Testing
     )
   }
 
+  @Test func privateStructPromotesWitnessesToFileprivate() throws {
+    assertMacro(
+      """
+      @Codable
+      private struct UserInfo {
+        let name: String
+        let age: Int
+      }
+      """,
+      expandedSource: """
+        private struct UserInfo {
+          let name: String
+          let age: Int
+
+          fileprivate func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(name, forKey: .name)
+            try container.encode(age, forKey: .age)
+          }
+        }
+
+        extension UserInfo: Codable {
+          enum CodingKeys: String, CodingKey {
+            case name
+            case age
+          }
+
+          fileprivate init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+            age = try container.decode(Int.self, forKey: .age)
+          }
+        }
+        """
+    )
+  }
+
+  @Test func fileprivateStructKeepsFileprivateWitnesses() throws {
+    assertMacro(
+      """
+      @Codable
+      fileprivate struct UserInfo {
+        let name: String
+      }
+      """,
+      expandedSource: """
+        fileprivate struct UserInfo {
+          let name: String
+
+          fileprivate func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(name, forKey: .name)
+          }
+        }
+
+        extension UserInfo: Codable {
+          enum CodingKeys: String, CodingKey {
+            case name
+          }
+
+          fileprivate init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+          }
+        }
+        """
+    )
+  }
+
   @Test func optionSkipProtocolConformanceDoesNotAttachConformance() throws {
     assertMacro(
       """


### PR DESCRIPTION
## Summary

`@Codable` (and `@Decodable` / `@Encodable`) on a `private` type generated `private init(from:)` / `private func encode(to:)`, which fails to compile:

```
error: initializer 'init(from:)' must be as accessible as its enclosing type
       because it matches a requirement in protocol 'Decodable'
note: mark the initializer as 'fileprivate' to satisfy the requirement
```

A protocol-requirement witness must be at least as accessible as its enclosing type. A top-level `private` type is effectively `fileprivate` for conformance purposes, so a `private` witness can't satisfy `Codable`.

## Changes

- Add a `witnessSafe` helper on `DeclModifierSyntax` that promotes `private` → `fileprivate` (preserving the original token's trivia) and leaves every other access level untouched. This mirrors what the Swift compiler does for its own synthesized `Codable` conformance.
- Apply it in both generation paths in `CodableMacro.swift`:
  - ExtensionMacro path (struct `init(from:)`)
  - MemberMacro path (`decodeModifiers` / `encodeModifiers` for structs and classes)
- Since `@Codable`, `@Decodable`, and `@Encodable` all route through `CodableMacro`, the single fix covers all three.

## Test plan

- [x] Reproduced the original compile failure; confirmed gone after the fix.
- [x] End-to-end decode/encode verified for `private struct`, `fileprivate struct`, `private class`, and `private` `@Decodable` / `@Encodable`.
- [x] Added regression tests: private struct, fileprivate struct, private class.
- [x] Full suite passes: **297 tests** (was 294).

🤖 Generated with [Claude Code](https://claude.com/claude-code)